### PR TITLE
Passe initiale pour access sur mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,29 +40,39 @@ Sentry.init({
 </script>
 
 <template>
-  <div id="main">
-    <Legend id="legend" @on-request-catastrophe-focus="focusCatastrophe"></Legend>
-    <MapView id="map-view" ref="map"></MapView>
-    <Timeline id="timeline"></Timeline>
+  <div id="main" class="container-fluid">
+    <div class="row">
+      <Legend id="legend" @on-request-catastrophe-focus="focusCatastrophe"
+          class="col-md-3">
+      </Legend>
+      <MapView id="map-view" ref="map" class="col-md-9"></MapView>
+    </div>
+    <div class="row">
+      <Timeline id="timeline"></Timeline>
+    </div>
   </div>
 </template>
 
 <style scoped>
 #main {
   height: 100vh;
-  display: grid;
-  grid-template-columns: 25% 1fr;
-  grid-template-rows: 1fr 96px;
-  grid-auto-flow: row;
+}
+
+#map-view {
+  height: calc(60vh - 96px);
+}
+@media (min-width: 768px) {  /* for devices >= 'md' */
+  #map-view {
+    height: calc(100vh - 96px);
+  }
 }
 
 #legend {
   padding: 10px;
-  height: calc(100vh - 96px);
+  max-height: calc(100vh - 96px);
 }
 
 #timeline {
-  grid-column: 1 / span 2;
   height: 96px;
 }
 </style>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -231,9 +231,16 @@ export default defineComponent({
     padding: 5px;
     background-color: rgba(255, 255, 255, 0.5);
 }
+#gradient div.step {
+    height: 8px;
+}
+@media (min-width: 768px) {  /* for devices >= 'md' */
+    #gradient div.step {
+        height: 16px;
+    }
+}
 
 #gradient div.step {
-    height: 16px;
     position: relative;
     opacity: 0.8;
 }

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,7 +1,7 @@
 <template>
-    <div id="timeline">
-        <div id="slidertitle">Année de recherche</div>
-        <div id="slidercontainer">
+    <div id="timeline" class="row">
+        <div id="slidertitle" class="col-md-2">Année de recherche</div>
+        <div id="slidercontainer" class="col-md-10">
             <vue-slider 
                 v-model="store.year"
                 :tooltip="'always'"
@@ -44,20 +44,12 @@ export default defineComponent({
 
 <style scoped>
 #timeline {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     padding: 30px;
 }
 
 #slidertitle {
     font-weight: bold;
     font-size: 1.2em;
-}
-
-#slidercontainer {
-    flex-grow: 1;
-    margin-left: 30px;
 }
 
 #slidercontainer input {


### PR DESCRIPTION
Remplace le CSS de grid pour utiliser les primitives de bootstrap. Sur
desktop, le site est sensiblement visuellement comme avant, mais sur
mobile il y a maintenant un layout different:
- la legende prend une row complete
- la map prend une row complete (avec 60vh au lieu de 100vh)
- la timeline tombe sur 2 lignes pour eviter les labels qui overlap

A consider par la suite: rendre la liste de candidats collapsible, les
catastrophes aussi (e.g. avec un "(X en $YEAR)" pour donner
l'information quand meme)

Desktop avant:
![image](https://user-images.githubusercontent.com/1843555/184559866-555abea6-e8c4-4e5a-99c8-6d7e00d4b971.png)

Desktop apres:
![image](https://user-images.githubusercontent.com/1843555/184559877-3d7c9205-36d7-44b1-ad51-0aca3d0d9008.png)


Mobile avant (Dimensions Pixel 5):
![image](https://user-images.githubusercontent.com/1843555/184559898-702f386a-374b-48dc-93f3-a2567c70274d.png)

Mobile apres (Dimensions Pixel 5):
![image](https://user-images.githubusercontent.com/1843555/184559918-3870574c-a4b8-4163-9a0a-a1a693586724.png)
