### PR TITLE
Afficher le nombre de catastrophes

### DIFF
--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -57,7 +57,8 @@
                     Candidat(e)s
                 </a>
             </h5>
-            <ul id ="body-candidates" class="list-group list-group-flush collapse show" aria-labelledby="heading-candidates">
+            <ul id ="body-candidates" class="list-group list-group-flush collapse show" aria-labelledby="heading-candidates"
+                ref="candidates">
                 <li v-for="candidate of store.selectedData.candidates" class="list-group-item candidate">
                     <span class="party" :class="candidate.party.toLowerCase()" :title="getPartyName(candidate.party)">{{
                             candidate.party
@@ -88,11 +89,17 @@
         </a>
         <div class="card" id="catastrophes">
             <h5 class="card-header" id="catastrophes-header">
-                <a data-bs-toggle="collapse" href="#body-catastrophes"
+                <a data-bs-toggle="collapse" data-bs-target="#body-catastrophes"
                     aria-expanded="true" aria-controls="body-catastrophes" id="heading-catastrophes"
                     class="d-block">
                     <i class="bi bi-chevron-up float-start"></i>
-                    <span>Catastrophes</span>
+                    <span>
+                        Catastrophes
+                    </span>
+                    <small class="float-end">{{store.selectedData.catastrophes.size}} en {{store.year}}</small>
+                    <div>
+                        <small class="d-block float-end">{{getTypeName(store.catastropheType)}}</small>
+                    </div>
                 </a>
             </h5>
             <div id="body-catastrophes" class="collapse show" aria-labelledby="heading-catastrophes">


### PR DESCRIPTION
Affiche un label avec le header de catastrophes. De cette facon, meme
lorsque la section est collapsed (eventuellement idealement par defaut
sur mobile), ca donne une idee du compte.

Puisque cela affiche le nombre de catastrophes post-filtrage, il est
alors important d'afficher le type de catastrophes affichees, surtout
lorsque la section est collapsed et le dropdown est maintenant cache.
J'ai ajoute un label pour le type de catastrophes, lorsque specifie.

# Mobile
![image](https://user-images.githubusercontent.com/1843555/184572496-e2be60b0-a64c-4671-9ed5-c8d0c40025e7.png)

# Mobile collapsed (ideallement le default a l'avenir)
![image](https://user-images.githubusercontent.com/1843555/184572521-a5cc0918-95d1-4c09-81d8-66ea5f562df4.png)

# Mobile collapsed + filtre
![image](https://user-images.githubusercontent.com/1843555/184572553-c42003bb-ce67-4933-997d-358d36ab0a78.png)

# Mobile expanded + filtre
![image](https://user-images.githubusercontent.com/1843555/184572576-2615ddb6-d44e-401c-bb95-8b04913a8ebd.png)

# Desktop
![image](https://user-images.githubusercontent.com/1843555/184572621-df1cd1ed-10ca-4f9c-915a-04c51979ccf9.png)
