### PR TITLE
Ajustements d'affichage de temperatures

### DIFF
--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -144,7 +144,7 @@ export default defineComponent({
         }
         const tempFormat = new Intl.NumberFormat('fr-CA', tempOptions);
         const relativeTempFormat = new Intl.NumberFormat('fr-CA', {
-            ...tempOptions, signDisplay: "exceptZero",
+            ...tempOptions, signDisplay: "always",
         });
         const precFormat = new Intl.NumberFormat('fr-CA', {
             useGrouping: false,

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -144,7 +144,7 @@ export default defineComponent({
         }
         const tempFormat = new Intl.NumberFormat('fr-CA', tempOptions);
         const relativeTempFormat = new Intl.NumberFormat('fr-CA', {
-            ...tempOptions, signDisplay: "always",
+            ...tempOptions, signDisplay: "exceptZero",
         });
         const precFormat = new Intl.NumberFormat('fr-CA', {
             useGrouping: false,

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -21,7 +21,7 @@
                     </div>
                     <div class="col stat" title="Augmentation par rapport à 1990">
                         <i class="bi bi-thermometer-high"></i>
-                        {{ tempFormat.format(store.selectedData.info.temp_increase) }}°C
+                        {{ relativeTempFormat.format(store.selectedData.info.temp_increase) }}°C
                     </div>
                     <div class="w-100"></div>
                     <div class="col stat" v-if="store.selectedData.info.avg_prec != undefined"
@@ -138,8 +138,13 @@ export default defineComponent({
             day: '2-digit',
             month: '2-digit'
         });
-        const tempFormat = new Intl.NumberFormat('fr-CA', {
+        const tempOptions = {
+            minimumFractionDigits: 1,
             maximumFractionDigits: 1,
+        }
+        const tempFormat = new Intl.NumberFormat('fr-CA', tempOptions);
+        const relativeTempFormat = new Intl.NumberFormat('fr-CA', {
+            ...tempOptions, signDisplay: "always",
         });
         const precFormat = new Intl.NumberFormat('fr-CA', {
             useGrouping: false,
@@ -155,6 +160,7 @@ export default defineComponent({
             getTypeName,
             dateFormat,
             tempFormat,
+            relativeTempFormat,
             precFormat,
             dayCountFormat
         }


### PR DESCRIPTION
Affiche le meme niveau de precision pour toutes les temperatures (e.g.
3.0), et pour la temperature relative a 1990, affiche toujours le signe
(pour aider a signaler que c'est une temperature relative).