### PR TITLE
Aucun overlay lorsque le delta de temp est <= 0

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -134,10 +134,13 @@ export default defineComponent({
                         if (region) {
                             const info = now.regions.get(region.id);
                             if (info) {
+                                // TODO: consider having a colour gradient for
+                                // increases <= 0
+                                const showOverlay = info.temp_increase > 0;
                                 geo.setStyle({
                                     ...meteoOverlayStyle,
                                     fillColor: temperatureGradient[getGradientColourIndex(info.temp_increase)],
-                                    fillOpacity: 0.5,
+                                    fillOpacity: showOverlay ? 0.5 : 0,
                                 });
                             }
                         }


### PR DESCRIPTION
Peut-etre qu'il serait mieux d'avoir un gradiant d'une autre couleur
(bleu? ou on veut garder le focus sur les rechauffements?), mais en
attendant c'est mieux de ne pas mettre d'overlay orange lorsque c'est
neutre/positif.

Exemple 2014:
![image](https://user-images.githubusercontent.com/1843555/184583641-ca59c9cf-e8b4-402b-9bc9-1b99d6d461e0.png)
