### PR TITLE
Utilisation de l'Infrastructure Géomatique Ouverte pour la carte de base

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -124,9 +124,9 @@ export default defineComponent({
                 maxZoom: MAX_ZOOM,
                 zoomControl: true
             });
-            L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            L.tileLayer("https://geoegl.msp.gouv.qc.ca/carto/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=carte_gouv_qc_public&STYLE=default&TILEMATRIXSET=EPSG_3857&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image%2Fpng", {
                 maxZoom: 19,
-                attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+                attribution: '<a href=\"https://www.quebec.ca/droit-auteur\">&copy; Gouvernement du Québec </a>'
             }).addTo(map);
             L.geoJSON(maskDataResponse.data, {
                 interactive: false,


### PR DESCRIPTION
Utilisation du point #3 mentionné sur cette page:
https://www.igouverte.org/documentation/page-services-igo/

C'est pas vraiment clair si on y a accès naturellement (c'est accessible aux "organismes", est-ce juste ceux du gouvernement, ou alors ça inclut Équiterre?), ou si ça va prendre une license d'Adresses Québec. Je laisse donc ça en draft en attendant de répondre à ces questions.

Le gros avantage d'utiliser ça plutôt qu'OpenStreetMap est qu'OSM est délibérément flou sur ce qu'ils considèrent une utilisation "raisonnable" de leur service: ils ont pas beaucoup de ressources, et ça throttle accoté. Si jamais en cours de route ils décident que notre application est trop populaire et envoie trop de requêtes, ils pourraient nous tirer la plogue.

Aussi, on est déjà jusqu'au coude avec les données du gouvernement du Québec, aussi bien y aller jusqu'au bout.