### PR TITLE
Ajustements carte

### DIFF
--- a/src/MobileApp.vue
+++ b/src/MobileApp.vue
@@ -90,7 +90,7 @@ export default defineComponent({
                 <MapView ref="mobileMap" class="map-view flex-grow-1" :district="userState.district"
                     :year="userState.year" :catastrophes="catastrophes" @district-selected="selectDistrict"
                     :location="userState.location" @location-changed="mapMoved" :zoom="userState.zoom"
-                    @zoom-changed="mapZoomed"></MapView>
+                    @zoom-changed="mapZoomed" :zoom-limit-offset="-1"></MapView>
                 <Statistics :district="userState.district" :year="userState.year"></Statistics>
             </tab>
             <tab name="Catastrophes" panel-class="tab-panel" :suffix="catastropheTabSuffix">

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="wrapper">
+    <div id="wrapper" ref="mapWrapper">
         <keep-alive>
             <div class="map" ref="mapElement"></div>
         </keep-alive>
@@ -46,6 +46,10 @@ export default defineComponent({
         zoom: {
             type: Number,
             default: MIN_ZOOM
+        },
+        zoomLimitOffset: {
+            type: Number,
+            default: 0
         }
     },
     setup(props, { emit }) {
@@ -106,7 +110,9 @@ export default defineComponent({
                 marker.addTo(iconLayer);
             }
         });
-        return { mapElement, map, mapLayer, iconLayer, statisticStore };
+        const mapWrapper = ref<HTMLDivElement | null>(null);
+        const mapResizeObserver = ref<ResizeObserver | null>(null);
+        return { mapElement, map, mapLayer, iconLayer, statisticStore, mapWrapper, mapResizeObserver };
     },
     computed: {
         selectedStatistics() {
@@ -121,8 +127,8 @@ export default defineComponent({
             const map = new L.Map(this.mapElement, {
                 center: this.location,
                 zoom: this.zoom,
-                minZoom: MIN_ZOOM,
-                maxZoom: MAX_ZOOM,
+                minZoom: MIN_ZOOM + this.zoomLimitOffset,
+                maxZoom: MAX_ZOOM + this.zoomLimitOffset,
                 zoomControl: true
             });
             L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -144,10 +150,29 @@ export default defineComponent({
             });
             map.addEventListener('zoomend', () => {
                 this.$emit('zoomChanged', map.getZoom());
-            })
+            });
+
+            L.control.scale({
+                imperial: false
+            }).addTo(map);
+
             this.map = map;
             this.map.setMaxBounds(this.mapLayer.getBounds().pad(0.05));
             this.map.attributionControl.setPrefix('');
+
+            if (this.mapWrapper) {
+                this.mapResizeObserver = new ResizeObserver(() => {
+                    map.invalidateSize({
+                        pan: true,
+                    });
+                });
+                this.mapResizeObserver.observe(this.mapWrapper);
+            }
+        }
+    },
+    unmounted() {
+        if (this.mapResizeObserver && this.mapWrapper) {
+            this.mapResizeObserver.unobserve(this.mapWrapper);
         }
     },
     methods: {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -117,6 +117,7 @@ export default defineComponent({
         if (this.mapElement) {
             const mapDataResponse = await axios.get<Polygon>("data/carte_electorale.json", { responseType: "json" });
             const maskDataResponse = await axios.get<Polygon>("data/masque_electoral.json", { responseType: "json" });
+
             const map = new L.Map(this.mapElement, {
                 center: this.location,
                 zoom: this.zoom,
@@ -125,7 +126,6 @@ export default defineComponent({
                 zoomControl: true
             });
             L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-                maxZoom: 19,
                 attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
             }).addTo(map);
             L.geoJSON(maskDataResponse.data, {
@@ -146,8 +146,8 @@ export default defineComponent({
                 this.$emit('zoomChanged', map.getZoom());
             })
             this.map = map;
-            this.map.setMaxBounds(this.mapLayer.getBounds());
-            this.map.attributionControl.setPrefix("");
+            this.map.setMaxBounds(this.mapLayer.getBounds().pad(0.05));
+            this.map.attributionControl.setPrefix('');
         }
     },
     methods: {


### PR DESCRIPTION
Recalculer la taille de la carte sur redimensionnement de son parent, et réduction des zooms minimaux et maximaux de 1 sur mobile pour compenser pour la petite taille de la carte sur cette plateforme. Également, ajout d'un léger padding autour de la zone limite de la carte pour laisser plus de jeu lors du drag proche de cette limite.