### PR TITLE
Petits ajustements sur mobile

### DIFF
--- a/src/MobileApp.vue
+++ b/src/MobileApp.vue
@@ -141,3 +141,8 @@ export default defineComponent({
     flex-direction: column;
 }
 </style>
+<style>
+a[role=tab] {
+    white-space: nowrap;
+}
+</style>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -161,10 +161,13 @@ export default defineComponent({
             this.map.attributionControl.setPrefix('');
 
             if (this.mapWrapper) {
-                this.mapResizeObserver = new ResizeObserver(() => {
-                    map.invalidateSize({
-                        pan: true,
-                    });
+                this.mapResizeObserver = new ResizeObserver(entries => {
+                    const rect = entries[0].contentRect;
+                    if (rect.width > 0 && rect.height > 0) {
+                        map.invalidateSize({
+                            pan: true,
+                        });
+                    }
                 });
                 this.mapResizeObserver.observe(this.mapWrapper);
             }

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -111,7 +111,7 @@ export default defineComponent({
         });
         const mapWrapper = ref<HTMLDivElement | null>(null);
         const mapResizeObserver = ref<ResizeObserver | null>(null);
-        return { mapElement, map, mapLayer, icons, statisticStore, mapWrapper, mapResizeObserver, i18n };
+        return { mapElement, map, mapLayer, icons, statisticStore, mapWrapper, mapResizeObserver, i18n, districtLayers };
     },
     computed: {
         selectedStatistics() {
@@ -167,6 +167,15 @@ export default defineComponent({
                     });
                 });
                 this.mapResizeObserver.observe(this.mapWrapper);
+            }
+
+            if (this.district) {
+                const layer = this.districtLayers.get(this.district.toString());
+                if (layer) {
+                    map.fitBounds(layer.layer.getBounds(), {
+                        animate: false
+                    });
+                }
             }
         }
     },


### PR DESCRIPTION
- Le compte de catastrophes sur le tab catastrophes est forcé sur la même ligne que le texte
- Si une circonscription est initialement sélectionné au chargement de la carte (par exemple, en cas de switch mobile <-> desktop), on le focus comme si on l'avait sélectionné directement (mais sans animation pour pas que ça jerk)
- Si le parent de la carte mesure 0x0, on skip l'étape d'invalidation de la carte, corrigeant un bug ou changer la sélection de circonscription sur un autre tab que celui de la carte dézoomait la carte à son minimum.