### PR TITLE
Formattage des dates en UTC.

### DIFF
--- a/src/locales/formats.ts
+++ b/src/locales/formats.ts
@@ -32,6 +32,7 @@ export const numberFormats = {
 export const datetimeFormats = {
     event_date: {
         day: '2-digit',
-        month: 'long'
+        month: 'long',
+        timeZone: 'UTC'
     }
 } as IntlDateTimeFormats;


### PR DESCRIPTION
Sans ça, on affiche la catastrophe comme ayant lieu un jour plus tôt qu'elle ne devrait être.