### PR TITLE
Base layout for carte v0.5, with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@500&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vire Au Vert</title>
   </head>

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,10 +89,10 @@ Sentry.init({
 
         <!-- TODO: desktop layout, ideally no split components -->
 
-        <div v-if="!loadingCompleted" class="loading-overlay">
+        <div v-if="loadingCompleted" class="loading-overlay">
             <!-- TODO: add spinner, e.g. with https://loading.io/css/ -->
             <div class="spinner-border" role="status" style="width: 5rem; height: 5rem;"></div>
-            <p class="loading-message">Chargement des données...</p>
+            <p class="loading-message" v-t="'loading'"></p>
         </div>
     </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,22 +61,131 @@ Sentry.init({
 </script>
 
 <template>
-    <div id="main" class="container-fluid">
-        <DesktopApp v-if="isDesktop" :userState="state"></DesktopApp>
-        <MobileApp v-else :userState="state"></MobileApp>
-        <div id="loading-overlay" v-if="!loadingCompleted">
+    <div class="main">
+        <!-- TODO: use real components -->
+        <header>
+            <!-- TODO: proper logo -->
+            <p>terre os</p>
+            <!-- TODO: proper logo -->
+            <p>Éqt*x(*)</p>
+        </header>
+
+        <section class="content-container">
+            <div class="primary-content content-section">
+                <div class="map">
+                    Map (+ inputs)
+                </div>
+                <div class="statistics">
+                    <h1 class="header">Température / année</h1>
+                    <div class="graph">TODO: graph</div>
+                </div>
+            </div>
+            <div class="secondary-content content-section">
+                <div class="thermometer">
+                </div>
+                <button class="call-to-action">Contactez vos candidats</button>
+            </div>
+        </section>
+
+        <!-- TODO: desktop layout, ideally no split components -->
+
+        <div v-if="!loadingCompleted" class="loading-overlay">
+            <!-- TODO: add spinner, e.g. with https://loading.io/css/ -->
             <div class="spinner-border" role="status" style="width: 5rem; height: 5rem;"></div>
-            <h3 class="mt-2">Chargement des données...</h3>
+            <p class="loading-message">Chargement des données...</p>
         </div>
     </div>
 </template>
 
 <style scoped>
-#main {
-    height: 100vh;
+.main {
+    min-height: 100vh;
+    padding: var(--sz-100);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sz-100);
 }
 
-#loading-overlay {
+header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 24px;  /* TODO: remove, use logos instead */
+}
+
+.content-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-grow: 1;
+    gap: var(--sz-100);
+}
+
+.content-section {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--sz-100);
+}
+
+.primary-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.secondary-content {
+    align-items: center;
+}
+
+.map {
+    background-color: green;  /* TODO: remove */
+    color: white;  /* TODO: remove */
+    min-height: 200px;
+    min-width: 100px;
+    flex-grow: 1;
+    border-radius: var(--sz-600);
+    padding: var(--sz-400) var(--sz-200);
+}
+
+.statistics {
+    background-color: var(--clr-beige);
+    border-radius: var(--sz-600);
+    padding: var(--sz-400) var(--sz-200);
+}
+
+.statistics .header {
+    color: var(--color-heading);
+    font-weight: 500;
+    font-size: var(--sz-400);
+}
+
+.graph {
+    min-height: 70px;  /* TODO: remove */
+}
+
+.thermometer {
+    width: 12px;  /* TODO: remove */
+    min-height: 300px;  /* TODO: remove */
+    border-radius: 16px;  /* TODO: remove */
+    border-style: solid;
+    border-width: 2px;
+    border-color: var(--clr-chaud);
+}
+
+.call-to-action {
+    font-size: var(--sz-400);
+    color: var(--clr-blanc);
+    background-color: var(--clr-orange);
+    border-radius: var(--sz-600);
+    width: min-content;
+    border: none;
+    cursor: pointer;
+    padding: var(--sz-300);
+    /* TODO: style on hover? */
+}
+
+.loading-overlay {
     position: fixed;
     top: 0;
     left: 0;
@@ -89,18 +198,8 @@ Sentry.init({
     justify-content: center;
     align-items: center;
 }
-</style>
 
-<style>
-/* global */
-.tab-panel {
-    padding-top: 10px;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-}
-
-.tab-panel>* {
-    margin-top: 10px;
+.loading-message {
+    font-size: var(--sz-600);
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,7 +89,7 @@ Sentry.init({
 
         <!-- TODO: desktop layout, ideally no split components -->
 
-        <div v-if="loadingCompleted" class="loading-overlay">
+        <div v-if="!loadingCompleted" class="loading-overlay">
             <!-- TODO: add spinner, e.g. with https://loading.io/css/ -->
             <div class="spinner-border" role="status" style="width: 5rem; height: 5rem;"></div>
             <p class="loading-message" v-t="'loading'"></p>

--- a/src/MobileApp.vue
+++ b/src/MobileApp.vue
@@ -123,7 +123,7 @@ export default defineComponent({
 }
 
 .map-view {
-    min-height: 400px;
+    min-height: 425px;
 }
 
 .search {

--- a/src/MobileApp.vue
+++ b/src/MobileApp.vue
@@ -123,7 +123,7 @@ export default defineComponent({
 }
 
 .map-view {
-    min-height: 425px;
+    min-height: 400px;
 }
 
 .search {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -1,53 +1,49 @@
-/* color palette from <https://github.com/vuejs/theme> */
+/* app style variables */
 :root {
-  --vt-c-white: #ffffff;
-  --vt-c-white-soft: #f8f8f8;
-  --vt-c-white-mute: #f2f2f2;
+  /* Note: naming based on Figma design comments */
 
-  --vt-c-black: #181818;
-  --vt-c-black-soft: #222222;
-  --vt-c-black-mute: #282828;
+  /* neutral colors */
+  --clr-blanc: #fbfbf8;
+  --clr-gris-tres-pale: #cdccc2;  /* "gris pale" for borders */
+  --clr-gris-pale: #b9b7a9;  /* "gris pale" for text */
+  --clr-gris-moyen: #74746f;
+  --clr-gris-mi-fonce: #4b4b4a;
+  --clr-gris-fonce: #353535;
 
-  --vt-c-indigo: #2c3e50;
+  /* accent colors */
+  --clr-beige: #f4f3e7;
+  --clr-orange: #ff6a0e;
+  --clr-alerte: #ff3b3b;
+  --clr-lichen: #a59e20;
 
-  --vt-c-divider-light-1: rgba(60, 60, 60, 0.29);
-  --vt-c-divider-light-2: rgba(60, 60, 60, 0.12);
-  --vt-c-divider-dark-1: rgba(84, 84, 84, 0.65);
-  --vt-c-divider-dark-2: rgba(84, 84, 84, 0.48);
+  /* TODO: other thermometer colors */
+  --clr-chaud: #c9655e;
 
-  --vt-c-text-light-1: var(--vt-c-indigo);
-  --vt-c-text-light-2: rgba(60, 60, 60, 0.66);
-  --vt-c-text-dark-1: var(--vt-c-white);
-  --vt-c-text-dark-2: rgba(235, 235, 235, 0.64);
+  /* TODO: catastrophes colors */
+
+  /* Size variants: 100 smallest to 900 biggest */
+  --sz-100: 8px;
+  --sz-200: 9px;
+  --sz-300: 10px;
+  --sz-400: 12px;
+  --sz-600: 16px;
+
+  /* Font weight variants */
+  --fw-regular: 500;
+
+  /* Font families */
+  --ff-primary: 'Noto Sans', sans-serif;  /* TODO: Matter instead? */
 }
 
 /* semantic color variables for this project */
 :root {
-  --color-background: var(--vt-c-white);
-  --color-background-soft: var(--vt-c-white-soft);
-  --color-background-mute: var(--vt-c-white-mute);
+  --color-background: var(--clr-blanc);
+  --color-background-accent: var(--clr-beige);
 
-  --color-border: var(--vt-c-divider-light-2);
-  --color-border-hover: var(--vt-c-divider-light-1);
+  --color-border: var(--clr-gris-pale);
 
-  --color-heading: var(--vt-c-text-light-1);
-  --color-text: var(--vt-c-text-light-1);
-
-  --section-gap: 160px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: var(--vt-c-black);
-    --color-background-soft: var(--vt-c-black-soft);
-    --color-background-mute: var(--vt-c-black-mute);
-
-    --color-border: var(--vt-c-divider-dark-2);
-    --color-border-hover: var(--vt-c-divider-dark-1);
-
-    --color-heading: var(--vt-c-text-dark-1);
-    --color-text: var(--vt-c-text-dark-2);
-  }
+  --color-text: var(--clr-gris-mi-fonce);
+  --color-heading: var(--clr-gris-fonce);
 }
 
 *,
@@ -56,7 +52,6 @@
   box-sizing: border-box;
   margin: 0;
   position: relative;
-  font-weight: normal;
 }
 
 body {
@@ -66,9 +61,9 @@ body {
   background: var(--color-background);
   transition: color 0.5s, background-color 0.5s;
   line-height: 1.6;
-  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  font-size: 15px;
+  font-family: var(--ff-primary);
+  font-weight: var(--fw-regular);
+  font-size: var(--sz-400);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -12,6 +12,9 @@ export default {
     at_location: "à {location}",
     count_by_year: "{count} en {year}",
 
+    // Loading overlay
+    loading: "Chargement des données...",
+
     // Catastrophes
 
     catastrophes: "Événement extrême | Événements extrêmes",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,6 @@ import { createApp } from 'vue'
 import App from './App.vue'
 
 import './assets/main.css'
-import "bootstrap/dist/css/bootstrap.min.css";
-import "bootstrap";
-import "bootstrap-icons/font/bootstrap-icons.css";
 import "vue-select/dist/vue-select.css";
 import { createI18n } from 'vue-i18n';
 import frCA from '@/locales/fr-CA';


### PR DESCRIPTION
Doing this in a separate carte-v0.5 branch for now, until the proper components are linked in (then we can merge in main and iterate).

- Define CSS vars with some of the colors/sizes from the Figma design, re-using the same names. Naming structure based on [this video series](https://www.youtube.com/watch?v=h3bTwCqX4ns&t=1787s) that I liked
- Remove bootstrap, use vanilla CSS instead
- Use 'Noto Sans' font for now, 'Matter' is not free
- Desktop layout is bad currently, waiting for proper design on Figma, then let's see if we can do it as just one component with CSS changes

Visually:
![image](https://user-images.githubusercontent.com/1843555/189507448-40ab3cf7-94b8-43f1-87f4-7d17c5af08f4.png)
