### PR TITLE
Add loading spinner from loading.io/css/

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import { DEFAULT_USER_STATE, UserState } from "./models/user";
 import CallToAction from './components/CallToAction.vue';
 import CatastropheToggle from "./components/CatastropheToggle.vue";
 import Header from "./components/Header.vue";
+import LoadingSpinner from "./components/LoadingSpinner.vue";
 import MapView from "./components/MapView.vue";
 import RegionSearch from "./components/RegionSearch.vue";
 import Thermometer from './components/Thermometer.vue';
@@ -22,6 +23,7 @@ export default defineComponent({
         CallToAction,
         CatastropheToggle,
         Header,
+        LoadingSpinner,
         MapView,
         RegionSearch,
         Thermometer,
@@ -137,8 +139,7 @@ Sentry.init({
         <!-- TODO: desktop layout, ideally no split components -->
 
         <div v-if="!loadingCompleted" class="loading-overlay">
-            <!-- TODO: add spinner, e.g. with https://loading.io/css/ -->
-            <div class="spinner-border" role="status" style="width: 5rem; height: 5rem;"></div>
+            <LoadingSpinner role="status"></LoadingSpinner>
             <p class="loading-message" v-t="'loading'"></p>
         </div>
     </div>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -42,6 +42,8 @@
   --color-background: var(--clr-blanc);
   --color-background-accent: var(--clr-beige);
 
+  --color-accent: var(--clr-orange);
+
   --color-border: var(--clr-gris-tres-pale);
 
   --color-text: var(--clr-gris-mi-fonce);

--- a/src/components/CallToAction.vue
+++ b/src/components/CallToAction.vue
@@ -15,7 +15,7 @@ export default defineComponent({
 a {
     font-size: var(--sz-400);
     color: var(--clr-blanc);
-    background-color: var(--clr-orange);
+    background-color: var(--color-accent);
     border-radius: var(--sz-600);
     width: min-content;
     border: none;

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -1,0 +1,55 @@
+<!-- From https://loading.io/css/ -->
+<template>
+    <div class="lds-ring">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+    </div>
+</template>
+
+<script lang="ts">
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+})
+</script>
+<style scoped>
+.lds-ring {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.lds-ring div {
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  width: 64px;
+  height: 64px;
+  margin: 8px;
+  border: 8px solid var(--color-accent);
+  border-radius: 50%;
+  animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border-color: var(--color-accent) transparent transparent transparent;
+}
+.lds-ring div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+.lds-ring div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+.lds-ring div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+@keyframes lds-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>
+

--- a/src/components/PillBadge.vue
+++ b/src/components/PillBadge.vue
@@ -20,7 +20,7 @@ div {
     border-radius: var(--sz-400);
     font-size: var(--sz-400);
     color: var(--clr-blanc);
-    background-color: var(--clr-orange);
+    background-color: var(--color-accent);
     padding: 1px var(--sz-50) 2px var(--sz-50);
 }
 </style>


### PR DESCRIPTION
From their website:
> All 12 CSS loading icons provided in this page are released under CC0 License, so just use them freely!

Drive-by change direct usages of `--clr-orange` to a `--color-accent`

Visually:
![image](https://user-images.githubusercontent.com/1843555/189536931-49d23e53-06d5-48e9-b64a-74505f8448ef.png)
