### PR TITLE
Add UI for catastrophe toggle settings

### DIFF
--- a/public/icons/check.svg
+++ b/public/icons/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4B4B4A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-check"><polyline points="20 6 9 17 4 12"></polyline></svg>

--- a/src/App.vue
+++ b/src/App.vue
@@ -201,14 +201,16 @@ Sentry.init({
     width: 100%;
     /* Note: must be this high to be over the overleaf z-index. */
     z-index: 1000;
-    padding: var(--sz-200) var(--sz-200);
+    padding: var(--sz-100) var(--sz-100);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     pointer-events: none;
+    gap: var(--sz-50);
 }
 
 .catastrophe-toggle {
+    overflow-y: hidden;
 }
 
 .region-search {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -73,7 +73,7 @@ body {
   color: var(--color-text);
   background: var(--color-background);
   transition: color 0.5s, background-color 0.5s;
-  line-height: 1.0;
+  line-height: 1.1;
   font-family: var(--ff-primary);
   font-weight: var(--fw-regular);
   font-size: var(--sz-400);

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -20,14 +20,21 @@
   --clr-chaud: #c9655e;
 
   /* TODO: catastrophes colors */
+  --clr-flood: #00C2CB;
+  --clr-forest-fire: #EC772E;
+  --clr-violent-storm: #E9C900;
+  --clr-tornado: #A6A6A6;
+  --clr-heat-wave: #DD3535;
 
   /* Size variants: from smallest to biggest */
+  --sz-30: 4px;
   --sz-50: 6px;
   --sz-100: 8px;
   --sz-200: 9px;
   --sz-300: 10px;
   --sz-400: 12px;
   --sz-600: 16px;
+  --sz-700: 24px;
   --sz-800: 26px;
 
   /* Font weight variants */
@@ -41,6 +48,8 @@
 :root {
   --color-background: var(--clr-blanc);
   --color-background-accent: var(--clr-beige);
+
+  --color-accent: var(--clr-orange);
 
   --color-border: var(--clr-gris-tres-pale);
 
@@ -64,7 +73,7 @@ body {
   color: var(--color-text);
   background: var(--color-background);
   transition: color 0.5s, background-color 0.5s;
-  line-height: 1.6;
+  line-height: 1.0;
   font-family: var(--ff-primary);
   font-weight: var(--fw-regular);
   font-size: var(--sz-400);

--- a/src/components/CallToAction.vue
+++ b/src/components/CallToAction.vue
@@ -20,7 +20,7 @@ a {
     width: min-content;
     border: none;
     cursor: pointer;
-    padding: var(--sz-100);
+    padding: var(--sz-400) var(--sz-100);
     text-align: center;
     text-decoration: none;
     /* TODO: style on hover? */

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -1,60 +1,178 @@
 <template>
     <!-- TODO: use real data -->
-    <!-- TODO: implement filtering pop-up -->
-    <section class="wrapper">
-        <header>
-            <div>
-                <!-- TODO: dynamic total count -->
-                <PillBadge class="total-count" :value="213"></PillBadge>
-                <!-- TODO: dynamic truncation -->
-                <span class="title">Év. extrêmes</span>
-            </div>
-            <!-- TODO: make interactive -->
+    <div class="wrapper" :class="{expanded: expanded}">
+        <section class="container">
+            <!-- Header row -->
+            <!-- TODO: dynamic total count -->
+            <PillBadge class="total-count pill" :value="213"></PillBadge>
+            <!-- TODO: dynamic truncation of text -->
+            <div class="title grid-col-span-2"><span>Év. extrêmes</span></div>
             <!-- TODO: hover styling -->
-            <button><img src="/icons/settings.svg"></button>
-        </header>
-    </section>
+            <button v-if="expanded" @click="expanded = false"><img src="/icons/x.svg"></button>
+            <button v-else @click="expanded = true"><img src="/icons/settings.svg"></button>
+
+            <template v-if="expanded" v-for="(toggle, index) in catastropheToggles">
+                <div v-if="index > 0" class="separator grid-col-span-row"></div>
+                <PillBadge class="pill"
+                    :class="[{invisible: toggle.count == 0}, toggle.pillClass]"
+                    :value="toggle.count"></PillBadge>
+                <img class="catastrophe-icon" :src="toggle.iconPath">
+                <div class="catastrophe-name"><span>{{toggle.name}}</span></div>
+                <Checkbox :name="$t('toggle_checkbox_name_prefix') + toggle.name"
+                    :checked="toggle.checked"></Checkbox>
+            </template>
+        </section>
+    </div>
 </template>
 
 <script lang="ts">
 
 import { defineComponent } from 'vue';
+import Checkbox from './Checkbox.vue';
 import PillBadge from './PillBadge.vue';
 
 export default defineComponent({
-    components: { PillBadge },
+    components: {
+        Checkbox,
+        PillBadge
+    },
+    data() {
+        return {
+            expanded: false,
+        };
+    },
+    computed: {
+        catastropheToggles() {
+            // TODO: this should be done based on a prop.
+            // TODO: put reminder to update this in model enum
+            return [
+                // TODO: keep track of checked state internally
+                // TODO: use localized names
+                {count: 213, iconPath: '/icons/attention.png',
+                 pillClass: 'catastrophe-all', name: 'Tous', checked: true},
+                {count: 37, iconPath: '/icons/flood_w.png',
+                 pillClass: 'catastrophe-flood', name: 'Innondations',
+                 checked: true},
+                {count: 24, iconPath: '/icons/forest_fire_w.png',
+                 pillClass: 'catastrophe-forest-fire', name: 'Feux de forêt',
+                 checked: false},
+                {count: 0, iconPath: '/icons/violent_storm_w.png',
+                 pillClass: 'catastrophe-violent-storm', name: 'Orages violents',
+                 checked: true},
+                {count: 8, iconPath: '/icons/tornado_w.png',
+                 pillClass: 'catastrophe-tornado', name: 'Tornades',
+                 checked: true},
+                {count: 144, iconPath: '/icons/heat_wave_w.png',
+                 pillClass: 'catastrophe-heat-wave', name: 'Vagues de chaleur',
+                 checked: true},
+            ]
+        },
+    },
 })
 </script>
 
 <style scoped>
-.wrapper {
-    padding-left: calc(var(--sz-100) + var(--size-map-zoom-control));
+.grid-col-span-2 {
+    grid-column: span 2;
 }
 
-header {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: var(--sz-100);
+.grid-col-span-row {
+    grid-column: 1 / -1;
+}
+
+.invisible {
+    visibility: hidden;
+}
+
+.wrapper {
+    --expand-transition: 0.5s ease;
+    padding-left: calc(var(--sz-100) + var(--size-map-zoom-control));
+    transition: padding-left var(--expand-transition);
+    transition: width var(--expand-transition);
+    height: 100%;
+}
+
+.expanded.wrapper {
+    padding-left: 0;
+}
+
+.container {
     border-radius: var(--sz-400);
     border: 1px solid var(--color-border);
     background-color: var(--color-background);
-    width: 100%;
-    height: var(--size-map-zoom-control);
+    transition: height var(--expand-transition);
+    display: grid;
+    padding: 0 var(--sz-100);
+    column-gap: var(--sz-30);
+    row-gap: 2px;
+    /* columns: count icon name checkbox */
+    grid-template-columns: auto auto 1fr auto;
+    align-items: center;
+    justify-items: center;
     /* re-enable pointer-events, parent overlay disables them */
     pointer-events: auto;
+    overflow-y: scroll;
+}
+
+.expanded .container {
+    height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .wrapper, .container {
+        transition: none;
+    }
 }
 
 .total-count {
     background-color: var(--clr-alerte);
 }
 
-.title {
-    margin-left: var(--sz-50);
+.title, .catastrophe-name {
+    width: 100%;
+    letter-spacing: -0.3px;
+    min-height: var(--size-map-zoom-control);
+    display: grid;
+    align-items: center;
+}
+
+.separator {
+    width: 100%;
+    height: 1px;
+    background-color: var(--clr-beige);
+    border-radius: var(--sz-600);
 }
 
 button img {
     vertical-align: middle;
+    width: var(--sz-700);
+    height: var(--sz-700);
+}
+
+.pill {
+    min-width: 34px;
+}
+
+.catastrophe-icon {
+    width: var(--sz-700);
+}
+
+.catastrophe-all {
+    background-color: var(--clr-alerte);
+}
+.catastrophe-flood {
+    background-color: var(--clr-flood);
+}
+.catastrophe-forest-fire {
+    background-color: var(--clr-forest-fire);
+}
+.catastrophe-violent-storm {
+    background-color: var(--clr-violent-storm);
+}
+.catastrophe-tornado {
+    background-color: var(--clr-tornado);
+}
+.catastrophe-heat-wave {
+    background-color: var(--clr-heat-wave);
 }
 </style>

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -1,0 +1,42 @@
+<template>
+    <input type="checkbox" />
+</template>
+
+<script lang="ts">
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+})
+</script>
+<style scoped>
+input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+    background-color: var(--color-background-accent);
+    width: var(--sz-700);
+    height: var(--sz-700);
+    border-radius: var(--sz-100);
+    box-shadow: 0px var(--sz-30) var(--sz-30)
+        rgba(255, 255, 255, 0.04),
+        inset 0px -1px 0px rgba(255, 255, 255, 0.66),
+        inset 0px 1px 2px rgba(0, 0, 0, 0.2);
+    display: grid;
+    place-content: center;
+}
+
+input[type="checkbox"]::before {
+    content: "";
+    transform: scale(0);
+    width: var(--sz-700);
+    height: var(--sz-700);
+    transform-origin: bottom left;
+    background: url("/icons/check.svg")
+}
+
+input[type="checkbox"]:checked::before {
+    transform: scale(1);
+}
+</style>
+

--- a/src/components/PillBadge.vue
+++ b/src/components/PillBadge.vue
@@ -22,5 +22,7 @@ div {
     color: var(--clr-blanc);
     background-color: var(--clr-orange);
     padding: 1px var(--sz-50) 2px var(--sz-50);
+    width: min-content;
+    text-align: center;
 }
 </style>

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -104,6 +104,9 @@ export default {
 
     no_future_catastrophes: "Les évênements extrêmes ne sont disponibles que pour les années passées",
 
+    // Catastrophe toggling
+    toggle_checkbox_name_prefix: "Affichage pour ",
+
     // Parties and candidates
 
     party_leaders: "Chef(fe)s de parti",


### PR DESCRIPTION
Note that the UI is purely visual currently, the values are static.

- Adjust some app-level spacing to make it fit
- Add a 'Checkbox' element that is styled like in Figma

Note that for now it only opens up to the search box instead of going over it like in the design. We might need to change that, but I punted on it here to avoid having to deal with the UI overlaying on top of an existing overlay (the map overlay).

Visually, unopened:

![image](https://user-images.githubusercontent.com/1843555/189549751-5dbfb642-16c9-40b7-a611-30ca2322f56f.png)

---

Visually, opened:

![image](https://user-images.githubusercontent.com/1843555/189549769-98c06652-406f-414e-8fcd-9d11eec0c1c9.png)


---