### PR TITLE
Implement catastrophe toggle logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@ import { defineComponent, reactive, ref, PropType } from "vue";
 import { useCandidateStore } from "./stores/candidates";
 import { useCatastropheStore } from "./stores/catastrophes";
 import { useStatisticStore } from "./stores/statistics";
-import { allCatastrophesFilter, Catastrophe } from "./models/catastrophes";
+import { FILTER_ALL_CATASTROPHES, Catastrophe } from "./models/catastrophes";
 import { DEFAULT_USER_STATE, UserState } from "./models/user";
 import CallToAction from './components/CallToAction.vue';
 import CatastropheToggle from "./components/CatastropheToggle.vue";
@@ -92,7 +92,7 @@ export default defineComponent({
         },
         allCatastrophes(): List<Catastrophe> {
             return this.catastropheStore.findCatastrophes(
-                this.state.year, this.state.district, allCatastrophesFilter())
+                this.state.year, this.state.district, FILTER_ALL_CATASTROPHES)
         },
     },
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@ import { defineComponent, reactive, ref, PropType } from "vue";
 import { useCandidateStore } from "./stores/candidates";
 import { useCatastropheStore } from "./stores/catastrophes";
 import { useStatisticStore } from "./stores/statistics";
-import { Catastrophe } from "./models/catastrophes";
+import { allCatastrophesFilter, Catastrophe } from "./models/catastrophes";
 import { DEFAULT_USER_STATE, UserState } from "./models/user";
 import CallToAction from './components/CallToAction.vue';
 import CatastropheToggle from "./components/CatastropheToggle.vue";
@@ -88,7 +88,11 @@ export default defineComponent({
         },
         catastrophes(): List<Catastrophe> {
             return this.catastropheStore.findCatastrophes(
-                this.state.year, this.state.district, this.state.catastrophe)
+                this.state.year, this.state.district, this.state.catastropheFilter)
+        },
+        allCatastrophes(): List<Catastrophe> {
+            return this.catastropheStore.findCatastrophes(
+                this.state.year, this.state.district, allCatastrophesFilter())
         },
     },
 });
@@ -116,8 +120,10 @@ Sentry.init({
                         :zoom="state.zoom" @zoom-changed="mapZoomed"
                         :zoom-limit-offset="-1"></MapView>
                     <div class="map-overlay">
-                        <CatastropheToggle
-                            class="catastrophe-toggle"></CatastropheToggle>
+                        <CatastropheToggle class="catastrophe-toggle"
+                            v-model:filter="state.catastropheFilter"
+                            :allCatastrophes="allCatastrophes"
+                            :currentCatastrophesCount="catastrophes.size"></CatastropheToggle>
                         <!-- TODO: change icon style -->
                         <!-- TODO: change to pop above? -->
                         <RegionSearch class="region-search"

--- a/src/DesktopApp.vue
+++ b/src/DesktopApp.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { List } from 'immutable';
+import { List, Set } from 'immutable';
 import CandidateList from "./components/CandidateList.vue";
 import CatastropheList from "./components/CatastropheList.vue";
 import Header from "./components/Header.vue";
@@ -8,7 +8,7 @@ import RegionSearch from "./components/RegionSearch.vue";
 import Statistics from "./components/Statistics.vue";
 import Timeline from "./components/Timeline.vue";
 import { defineComponent, PropType, ref } from "vue";
-import { Catastrophe, CatastropheFilter } from "./models/catastrophes";
+import { Catastrophe, CatastropheType } from "./models/catastrophes";
 import { CURRENT_YEAR } from "./models/constants";
 import { DEFAULT_USER_STATE, UserState } from "./models/user";
 import { useCatastropheStore } from "./stores/catastrophes";
@@ -46,8 +46,8 @@ export default defineComponent({
         selectYear(year: number) {
             this.userState.year = year;
         },
-        selectCatastropheType(catastropheType: CatastropheFilter) {
-            this.userState.catastrophe = catastropheType;
+        selectCatastropheType(catastropheType: CatastropheType) {
+            this.userState.catastropheFilter = Set([catastropheType]);
         },
         mapMoved(location: [number, number]) {
             this.userState.location = location;
@@ -62,7 +62,8 @@ export default defineComponent({
         },
         catastrophes(): List<Catastrophe> {
             return this.catastropheStore.findCatastrophes(
-                this.userState.year, this.userState.district, this.userState.catastrophe)
+                this.userState.year, this.userState.district,
+                this.userState.catastropheFilter)
         }
     }
 });

--- a/src/MobileApp.vue
+++ b/src/MobileApp.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { List } from 'immutable';
+import { List, Set } from 'immutable';
 import { Tabs, Tab } from 'vue3-tabs-component';
 import CandidateList from "./components/CandidateList.vue";
 import CatastropheList from "./components/CatastropheList.vue";
@@ -9,7 +9,7 @@ import RegionSearch from "./components/RegionSearch.vue";
 import Statistics from "./components/Statistics.vue";
 import Timeline from "./components/Timeline.vue";
 import { defineComponent, PropType, ref } from "vue";
-import { Catastrophe, CatastropheFilter } from "./models/catastrophes";
+import { Catastrophe, CatastropheType } from "./models/catastrophes";
 import { useCatastropheStore } from "./stores/catastrophes";
 import { CURRENT_YEAR } from "./models/constants";
 import { DEFAULT_USER_STATE, UserState } from "./models/user";
@@ -51,8 +51,8 @@ export default defineComponent({
         selectYear(year: number) {
             this.userState.year = year;
         },
-        selectCatastropheType(catastropheType: CatastropheFilter) {
-            this.userState.catastrophe = catastropheType;
+        selectCatastropheType(catastropheType: CatastropheType) {
+            this.userState.catastropheFilter = Set([catastropheType]);
         },
         mapMoved(location: [number, number]) {
             this.userState.location = location;
@@ -67,7 +67,8 @@ export default defineComponent({
     computed: {
         catastrophes(): List<Catastrophe> {
             return this.catastropheStore.findCatastrophes(
-                this.userState.year, this.userState.district, this.userState.catastrophe)
+                this.userState.year, this.userState.district,
+                this.userState.catastropheFilter)
         },
         catastropheTabSuffix() {
             // Tab library we're using doesn't have slots, so we generate HTML by hand

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -19,12 +19,14 @@
   /* TODO: other thermometer colors */
   --clr-chaud: #c9655e;
 
-  /* TODO: catastrophes colors */
   --clr-flood: #00C2CB;
   --clr-forest-fire: #EC772E;
   --clr-violent-storm: #E9C900;
   --clr-tornado: #A6A6A6;
   --clr-heat-wave: #DD3535;
+  --clr-freezing-rain: #004AAD;
+  --clr-storm-winds: #5271FF;
+
 
   /* Size variants: from smallest to biggest */
   --sz-30: 4px;

--- a/src/components/CatastropheList.vue
+++ b/src/components/CatastropheList.vue
@@ -29,11 +29,13 @@
 </template>
 
 <script lang="ts">
-import { Catastrophe, CatastropheFilter, CatastropheType } from '@/models/catastrophes';
+import { Set } from 'immutable';
+import { allCatastrophesFilter, Catastrophe, CatastropheType } from '@/models/catastrophes';
 import { CURRENT_YEAR } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { defineComponent, ref } from 'vue';
 
+type SingleCatastropheFilter = CatastropheType | '';
 
 export default defineComponent({
     emits: ['onRequestCatastropheFocus', 'onFilterCatastrophes'],
@@ -50,7 +52,7 @@ export default defineComponent({
     setup() {
         const catastropheTypes = Object.values(CatastropheType);
         const catastropheStore = useCatastropheStore();
-        const catastropheType = ref<CatastropheFilter>('');
+        const catastropheType = ref<SingleCatastropheFilter>('');
 
         return {
             catastropheTypes,
@@ -60,8 +62,11 @@ export default defineComponent({
     },
     computed: {
         catastrophes() {
+            const filter = this.catastropheType ?
+                Set([this.catastropheType])
+                : allCatastrophesFilter();
             return this.catastropheStore.findCatastrophes(
-                this.year, this.district, this.catastropheType);
+                this.year, this.district, filter);
         },
         areCatastrophesAvailable() {
             return this.year <= CURRENT_YEAR;

--- a/src/components/CatastropheList.vue
+++ b/src/components/CatastropheList.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import { Set } from 'immutable';
-import { allCatastrophesFilter, Catastrophe, CatastropheType } from '@/models/catastrophes';
+import { FILTER_ALL_CATASTROPHES, Catastrophe, CatastropheType } from '@/models/catastrophes';
 import { CURRENT_YEAR } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { defineComponent, ref } from 'vue';
@@ -62,9 +62,7 @@ export default defineComponent({
     },
     computed: {
         catastrophes() {
-            const filter = this.catastropheType ?
-                Set([this.catastropheType])
-                : allCatastrophesFilter();
+            const filter = this.catastropheType ? Set([this.catastropheType]) : FILTER_ALL_CATASTROPHES;
             return this.catastropheStore.findCatastrophes(
                 this.year, this.district, filter);
         },

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -1,10 +1,8 @@
 <template>
-    <!-- TODO: use real data -->
     <div class="wrapper" :class="{expanded: expanded}">
         <section class="container">
             <!-- Header row -->
-            <!-- TODO: dynamic total count -->
-            <PillBadge class="total-count pill" :value="213"></PillBadge>
+            <PillBadge class="total-count pill" :value="currentCatastrophesCount"></PillBadge>
             <!-- TODO: dynamic truncation of text -->
             <div class="title grid-col-span-2"><span>Év. extrêmes</span></div>
             <!-- TODO: hover styling -->
@@ -19,6 +17,7 @@
                 <img class="catastrophe-icon" :src="toggle.iconPath">
                 <div class="catastrophe-name"><span>{{toggle.name}}</span></div>
                 <Checkbox :name="$t('toggle_checkbox_name_prefix') + toggle.name"
+                    @change="e => toggle.onChange(e.target.checked)"
                     :checked="toggle.checked"></Checkbox>
             </template>
         </section>
@@ -27,11 +26,80 @@
 
 <script lang="ts">
 
-import { defineComponent } from 'vue';
+import { List, Set } from "immutable";
+import { defineComponent, PropType } from 'vue';
+import type { CatastropheFilter } from "@/models/catastrophes";
+import { allCatastrophesFilter, Catastrophe, CatastropheType } from "@/models/catastrophes";
 import Checkbox from './Checkbox.vue';
 import PillBadge from './PillBadge.vue';
 
+// If new catastrophe types are added, this must be changed:
+const TOGGLES = [
+    {
+        type: CatastropheType.Flood,
+        iconPath: '/icons/flood_w.png',
+        pillClass: 'catastrophe-flood',
+    },
+    {
+        type: CatastropheType.ForestFire,
+        iconPath: '/icons/forest_fire_w.png',
+        pillClass: 'catastrophe-forest-fire',
+    },
+    {
+        type: CatastropheType.ViolentStorm,
+        iconPath: '/icons/violent_storm_w.png',
+        pillClass: 'catastrophe-violent-storm',
+    },
+    {
+        type: CatastropheType.Tornado,
+        iconPath: '/icons/tornado_w.png',
+        pillClass: 'catastrophe-tornado',
+    },
+    {
+        type: CatastropheType.HeatWave,
+        iconPath: '/icons/heat_wave_w.png',
+        pillClass: 'catastrophe-heat-wave',
+    },
+    {
+        type: CatastropheType.FreezingRain,
+        iconPath: '/icons/freezing_rain_w.png',
+        pillClass: 'catastrophe-freezing-rain',
+    },
+    {
+        type: CatastropheType.StormWinds,
+        iconPath: '/icons/storm_winds_w.png',
+        pillClass: 'catastrophe-storm-winds',
+    },
+    // Note: WinterStorm not included, we don't display them currently.
+];
+
+type OnChangeFn = (checked: Boolean) => void;
+
+type Toggle = {
+    count: number,
+    iconPath: string,
+    pillClass: string,
+    name: string,
+    checked: boolean,
+    onChange: OnChangeFn,
+}
+
 export default defineComponent({
+    emits: ['update:filter'],
+    props: {
+        filter: {
+            type: Object as PropType<CatastropheFilter>,
+            required: true,
+        },
+        allCatastrophes: {  // Note: *not* the type-filtered ones.
+            type: Object as PropType<List<Catastrophe>>,
+            required: true,
+        },
+        currentCatastrophesCount: {
+            type: Number,
+            required: true,
+        },
+    },
     components: {
         Checkbox,
         PillBadge
@@ -42,30 +110,47 @@ export default defineComponent({
         };
     },
     computed: {
-        catastropheToggles() {
-            // TODO: this should be done based on a prop.
-            // TODO: put reminder to update this in model enum
-            return [
-                // TODO: keep track of checked state internally
-                // TODO: use localized names
-                {count: 213, iconPath: '/icons/attention.png',
-                 pillClass: 'catastrophe-all', name: 'Tous', checked: true},
-                {count: 37, iconPath: '/icons/flood_w.png',
-                 pillClass: 'catastrophe-flood', name: 'Innondations',
-                 checked: true},
-                {count: 24, iconPath: '/icons/forest_fire_w.png',
-                 pillClass: 'catastrophe-forest-fire', name: 'Feux de forêt',
-                 checked: false},
-                {count: 0, iconPath: '/icons/violent_storm_w.png',
-                 pillClass: 'catastrophe-violent-storm', name: 'Orages violents',
-                 checked: true},
-                {count: 8, iconPath: '/icons/tornado_w.png',
-                 pillClass: 'catastrophe-tornado', name: 'Tornades',
-                 checked: true},
-                {count: 144, iconPath: '/icons/heat_wave_w.png',
-                 pillClass: 'catastrophe-heat-wave', name: 'Vagues de chaleur',
-                 checked: true},
-            ]
+        catastropheToggles(): List<Toggle> {
+            var toggles: Toggle[] = [];
+            toggles.push({
+                count: this.allCatastrophes.size,
+                iconPath: '/icons/attention.png',
+                pillClass: 'catastrophe-all',
+                name: this.$t('all_catastrophes'),
+                checked: this.filter.equals(allCatastrophesFilter()),
+                onChange: this.onFilterAllChange,
+            });
+            for (const toggle of TOGGLES) {
+                const count = this.allCatastrophes.filter(
+                    c => c.type == toggle.type).size;
+                toggles.push({
+                    count: count,
+                    iconPath: toggle.iconPath,
+                    pillClass: toggle.pillClass,
+                    name: this.$t(`catastrophe_${toggle.type}`, 2),
+                    checked: this.filter.includes(toggle.type),
+                    onChange: e => this.onFilterChange(e, toggle.type),
+                });
+            }
+            return List(toggles);
+        },
+    },
+    methods: {
+        onFilterAllChange(enable: Boolean) {
+            // When the 'All' option is checked, it either clears all filters or
+            // enables them all.
+            if (enable) {
+                this.$emit('update:filter', allCatastrophesFilter());
+            } else {
+                this.$emit('update:filter', Set());
+            }
+        },
+        onFilterChange(enable: Boolean, type: CatastropheType) {
+            if (enable) {
+                this.$emit('update:filter', this.filter.add(type));
+            } else {
+                this.$emit('update:filter', this.filter.delete(type));
+            }
         },
     },
 })
@@ -115,7 +200,7 @@ export default defineComponent({
 }
 
 .expanded .container {
-    height: 100%;
+    max-height: 100%;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -174,5 +259,11 @@ button img {
 }
 .catastrophe-heat-wave {
     background-color: var(--clr-heat-wave);
+}
+.catastrophe-freezing-rain {
+    background-color: var(--clr-freezing-rain);
+}
+.catastrophe-storm-winds {
+    background-color: var(--clr-storm-winds);
 }
 </style>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -43,7 +43,7 @@ import 'vue-slider-component/theme/default.css'
 import { TIMELINE_YEARS,BEGIN_MODELED_YEAR } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { useStatisticStore } from '@/stores/statistics';
-import { allCatastrophesFilter, CatastropheFilter } from '@/models/catastrophes';
+import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from '@/models/catastrophes';
 import { Line } from 'vue-chartjs'
 import CandidateList from './CandidateList.vue';
 import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PointElement, LineElement, ChartOptions} from 'chart.js'
@@ -125,7 +125,7 @@ export default defineComponent({
     methods: {
         catastrophesCountByYears(year: number): Number {
             return this.catastropheStore.findCatastrophes(year, this.district,
-                this.catastropheFilter ?? allCatastrophesFilter()).size;
+                this.catastropheFilter ?? FILTER_ALL_CATASTROPHES).size;
         },
         catastropheCountSizeClass(year: number): String {
             const catastropheCount = this.catastrophesCountByYears(year);

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -43,7 +43,7 @@ import 'vue-slider-component/theme/default.css'
 import { TIMELINE_YEARS,BEGIN_MODELED_YEAR } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { useStatisticStore } from '@/stores/statistics';
-import { CatastropheFilter } from '@/models/catastrophes';
+import { allCatastrophesFilter, CatastropheFilter } from '@/models/catastrophes';
 import { Line } from 'vue-chartjs'
 import CandidateList from './CandidateList.vue';
 import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PointElement, LineElement, ChartOptions} from 'chart.js'
@@ -64,8 +64,7 @@ export default defineComponent({
             default: 0
         },
         catastropheFilter: {
-            type: String as PropType<CatastropheFilter>,
-            default: ''
+            type: Object as PropType<CatastropheFilter>,
         },
         district: {
             type: Number,
@@ -125,7 +124,8 @@ export default defineComponent({
     },
     methods: {
         catastrophesCountByYears(year: number): Number {
-            return this.catastropheStore.findCatastrophes(year, this.district, this.catastropheFilter).size;
+            return this.catastropheStore.findCatastrophes(year, this.district,
+                this.catastropheFilter ?? allCatastrophesFilter()).size;
         },
         catastropheCountSizeClass(year: number): String {
             const catastropheCount = this.catastrophesCountByYears(year);

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -106,6 +106,7 @@ export default {
 
     // Catastrophe toggling
     toggle_checkbox_name_prefix: "Affichage pour ",
+    all_catastrophes: "Tous",
 
     // Parties and candidates
 

--- a/src/models/catastrophes.ts
+++ b/src/models/catastrophes.ts
@@ -1,4 +1,4 @@
-import { List } from "immutable";
+import { List, Set } from "immutable";
 
 export enum CatastropheType {
     Flood = "FLOOD",
@@ -8,10 +8,11 @@ export enum CatastropheType {
     FreezingRain = "FREEZING_RAIN",
     WinterStorm = "WINTER_STORM",
     StormWinds = "STORM_WINDS",
-    HeatWave = "HEAT_WAVE"
+    HeatWave = "HEAT_WAVE",
+    // IFCHANGE: Add support to CatastropheToggle
 }
 
-export type CatastropheFilter = CatastropheType | '';
+export type CatastropheFilter = Set<CatastropheType>;
 
 export interface CatastropheLocation {
     lat: number;
@@ -46,6 +47,10 @@ export interface CatastropheDocument {
     severity: Severity;
     district: number;
     loc_approx: boolean;
+}
+
+export function allCatastrophesFilter(): CatastropheFilter {
+    return Set(Object.values(CatastropheType));
 }
 
 export function parseCatatrophe(doc: CatastropheDocument): Catastrophe {

--- a/src/models/catastrophes.ts
+++ b/src/models/catastrophes.ts
@@ -6,13 +6,14 @@ export enum CatastropheType {
     ViolentStorm = "VIOLENT_STORM",
     Tornado = "TORNADO",
     FreezingRain = "FREEZING_RAIN",
-    WinterStorm = "WINTER_STORM",
     StormWinds = "STORM_WINDS",
     HeatWave = "HEAT_WAVE",
     // IFCHANGE: Add support to CatastropheToggle
 }
 
 export type CatastropheFilter = Set<CatastropheType>;
+
+export const FILTER_ALL_CATASTROPHES = Set(Object.values(CatastropheType));
 
 export interface CatastropheLocation {
     lat: number;
@@ -47,10 +48,6 @@ export interface CatastropheDocument {
     severity: Severity;
     district: number;
     loc_approx: boolean;
-}
-
-export function allCatastrophesFilter(): CatastropheFilter {
-    return Set(Object.values(CatastropheType));
 }
 
 export function parseCatatrophe(doc: CatastropheDocument): Catastrophe {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,10 +1,10 @@
-import { CatastropheFilter } from "./catastrophes";
+import { allCatastrophesFilter, CatastropheFilter } from "./catastrophes";
 import { CURRENT_YEAR } from "./constants";
 
 export interface UserState {
     district: number;
     year: number;
-    catastrophe: CatastropheFilter;
+    catastropheFilter: CatastropheFilter;
     location: [number, number];
     zoom: number;
 }
@@ -12,7 +12,7 @@ export interface UserState {
 export const DEFAULT_USER_STATE: UserState = {
     district: 0,
     year: CURRENT_YEAR,
-    catastrophe: '',
+    catastropheFilter: allCatastrophesFilter(),
     location: [45.5001, -73.5679],
     zoom: 11
 };

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,4 +1,4 @@
-import { allCatastrophesFilter, CatastropheFilter } from "./catastrophes";
+import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from "./catastrophes";
 import { CURRENT_YEAR } from "./constants";
 
 export interface UserState {
@@ -12,7 +12,7 @@ export interface UserState {
 export const DEFAULT_USER_STATE: UserState = {
     district: 0,
     year: CURRENT_YEAR,
-    catastropheFilter: allCatastrophesFilter(),
+    catastropheFilter: FILTER_ALL_CATASTROPHES,
     location: [45.5001, -73.5679],
     zoom: 11
 };

--- a/src/models/yearly_data.ts
+++ b/src/models/yearly_data.ts
@@ -20,13 +20,14 @@ export function parseYearlyStatistics(doc: YearlyStatisticsDocument): YearlyStat
     return Map(Object.entries(doc).map(([region, stats]) => [parseInt(region), stats]));
 }
 
-export function filterCatastrophesByRegion(catastropes: List<Catastrophe>, district: number, type: CatastropheFilter): List<Catastrophe> {
-    if (district === 0 && type === '') {
+export function filterCatastrophesByRegion(catastropes: List<Catastrophe>, district: number,
+    filter: CatastropheFilter): List<Catastrophe> {
+    if (district === 0) {
         return catastropes;
     }
 
     return catastropes.filter(x => {
-        if (type && x.type !== type) {
+        if (!filter.includes(x.type)) {
             return false;
         }
         return district === 0 || district === x.district;

--- a/src/stores/catastrophes.ts
+++ b/src/stores/catastrophes.ts
@@ -10,13 +10,13 @@ export const useCatastropheStore = defineStore('catastropheStore', {
         };
     },
     getters: {
-        findCatastrophes: state => (year: number, district = 0, typeFilter: CatastropheFilter = '') => {
+        findCatastrophes: state => (year: number, district = 0, filter: CatastropheFilter) => {
             let catastrophes = state.catastrophes.get(year) ?? List();
             if (district) {
                 catastrophes = catastrophes.filter(x => x.district === district);
             }
-            if (typeFilter) {
-                catastrophes = catastrophes.filter(x => x.type === typeFilter);
+            if (filter) {
+                catastrophes = catastrophes.filter(x => filter.includes(x.type));
             }
             return catastrophes;
         }

--- a/src/stores/catastrophes.ts
+++ b/src/stores/catastrophes.ts
@@ -15,9 +15,7 @@ export const useCatastropheStore = defineStore('catastropheStore', {
             if (district) {
                 catastrophes = catastrophes.filter(x => x.district === district);
             }
-            if (filter) {
-                catastrophes = catastrophes.filter(x => filter.includes(x.type));
-            }
+            catastrophes = catastrophes.filter(x => filter.includes(x.type));
             return catastrophes;
         }
     },


### PR DESCRIPTION
Change CatastropheFilter to be a Set of CatastropheType. The toggle makes changes to this set.

The 'title' bar on the toggle ("X Évenements extrêmes") shows the current filtered count, while the toggle shows the count on each row for the unfiltered amount.

Note: made changes to Desktop/Mobile App components to make the build happy, but did not test it out.

Visuals are the same, but now the values shown are real:

![image](https://user-images.githubusercontent.com/1843555/189557821-b2f80f44-0f89-4c6e-ba6c-5870639dfc43.png)
