### PR TITLE
Ajoute l'unité sur l'axe des y

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -8,6 +8,8 @@
                 :height="70"
                 :width="0"
                 :chart-options="chartOptions"/>
+            <!-- Apparently it's not possible not to display the Y axis label not rotated https://github.com/chartjs/Chart.js/issues/8345 -->
+            <span class="graph-unit">C</span>
         </div>
         <div id="slidercontainer">
             <vue-slider
@@ -103,7 +105,7 @@ export default defineComponent({
                 },
                 scales: {
                     x: {
-                        display: false
+                        display: false,
                     },
                     y: {
                         ticks: {
@@ -156,9 +158,6 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.timeline {
-}
-
 #slidertitle {
     font-weight: bold;
     font-size: 1.2em;
@@ -245,6 +244,11 @@ export default defineComponent({
         display:block;
         margin-top: 0;
     }
+}
+
+.graph-unit {
+    left: -7px;
+    top: -17px;
 }
 </style>
 


### PR DESCRIPTION
La fonctionnalité de base de chart-js permet d'afficher un label sur l'axe des y mais celui ci est rotaté de 90 degrées. Chart-js ne permet par de la dérotaté (https://github.com/chartjs/Chart.js/issues/8345). Cette solution me semble plus simple que les autres proposées sur github.

![image](https://user-images.githubusercontent.com/495858/189561691-00843353-d49e-4c36-a55e-47bee5087170.png)
