### PR TITLE
Fix visual bug on expanded events toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -214,7 +214,8 @@ Sentry.init({
 }
 
 .catastrophe-toggle {
-    overflow-y: auto;
+    min-height: 0;  /* undo min-height: auto from being a flex child */
+    max-height: 100%;
 }
 
 .region-search {

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -191,6 +191,8 @@ export default defineComponent({
     justify-items: center;
     /* re-enable pointer-events, parent overlay disables them */
     pointer-events: auto;
+    overflow-y: auto;
+    max-height: 100%;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Because the overflow-y was on the entire component, the bottom border would not be rounded anymore, which looked off. Fixed by moving the overflow into the CatastropheToggle component, with necessary changes around that to allow it to expand still.

Compare the following to https://github.com/Drahakar/vireauvert/pull/121 to see the difference:
![image](https://user-images.githubusercontent.com/1843555/189794800-ea061d0b-22cb-4f01-aaa1-7a9dbbebff33.png)
