### PR TITLE
Subsitution de l'opérateur de spread avec une construction a bras

### DIFF
--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -30,10 +30,7 @@ export function setMapLayerColour(layer: L.GeoJSON, selected: boolean, tempDelta
     if (tempDelta) {
         let colour = temperatureGradient[getGradientColourIndex(tempDelta)];
         colour = multiplyColours(colour, [1, 0, 0], 0.9);
-        style = {
-            ...style,
-            fillColor: colourToHex(colour)
-        };
+        style.fillColor = colourToHex(colour);
     }
     layer.setStyle(style);
 

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -63,8 +63,14 @@ function createMarkerPopup(group: CatastropheGroup, i18n: Composer) {
     list.classList.add('list-group', 'list-group-flush');
     for (const instance of group.instances) {
         const catastrophe: Catastrophe = {
-            ...group,
-            ...instance
+            id: instance.id,
+            city: group.city,
+            date: instance.date,
+            district: group.district,
+            loc_approx: group.loc_approx,
+            location: group.location,
+            severity: instance.severity,
+            type: group.type
         }
 
         const time = document.createElement('time');


### PR DESCRIPTION
L'operateur de spread apparaissait comme un hotspot durant le profiling

Avant: 
![image](https://user-images.githubusercontent.com/495858/189806943-58358c23-bea1-428e-acf8-0de9c532d9db.png)

Après : 
![image](https://user-images.githubusercontent.com/495858/189806116-d90bb1ad-7acc-44f3-b826-08ae6bd814df.png)
