### PR TITLE
Thermometer show avg temperature (absolute)

### DIFF
--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -54,7 +54,8 @@ export default defineComponent({
         notchValue(): number {
             // Return a float that maps to what notch index the current value
             // would map to, allowing to be in-between notches.
-            return this.statistics.avg_temp - MIN_NOTCH;
+            const avg_temp = this.statistics.avg_temp ?? 0;
+            return avg_temp - MIN_NOTCH;
         }
     },
 })

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -9,11 +9,12 @@
             </div>
         </div>
 
-        <!-- TODO: proper formatting of delta temp -->
-        <span v-for="notchNum in numNotches" class="notch"
-            :style="{'--notch-idx': notchNum - 1}">
-            {{minNotch + notchNum - 1}}
-        </span>
+        <template v-for="notchNum in numNotches">
+            <span v-if="(notchNum - 1) % notchSteps == 0" class="notch"
+                :style="{'--notch-idx': notchNum - 1}">
+                {{$n(minNotch + notchNum - 1, 'integer')}}
+            </span>
+        </template>
 
         <!-- TODO: emojis -->
         <!-- TODO: show current value -->
@@ -26,15 +27,16 @@
 import { defineComponent, PropType } from 'vue';
 import { RegionStatistics } from '@/models/yearly_data';
 
-const MIN_NOTCH = -1;
-const MAX_NOTCH = 7;
+const MIN_NOTCH = -6;
+const MAX_NOTCH = 10;
+const NOTCH_STEPS = 2;  // Only display a notch every NOTCH_STEPS notches
 const NUM_NOTCHES = MAX_NOTCH - MIN_NOTCH + 1;
 
 export default defineComponent({
     props: {
         statistics: {
             type: Object as PropType<RegionStatistics>,
-            default: {}
+            required: true,
         },
         district: {
             type: Number,
@@ -45,14 +47,14 @@ export default defineComponent({
         return {
             numNotches: NUM_NOTCHES,
             minNotch: MIN_NOTCH,
+            notchSteps: NOTCH_STEPS,
         };
     },
     computed: {
         notchValue(): number {
             // Return a float that maps to what notch index the current value
             // would map to, allowing to be in-between notches.
-            const delta = this.statistics.temp_delta ?? 0;
-            return delta - MIN_NOTCH;
+            return this.statistics.avg_temp - MIN_NOTCH;
         }
     },
 })


### PR DESCRIPTION
Showing from -3 to 4 like in the current design would not work either
because a lot of 1990 temperatures are outside that, too. I decided to
go from -6 to 10 with steps of 2 (one more notch), since that allows
representing almost all 1990 values in-bounds (-7.3 to 8.8), with some
space to have their +1.5C point not show up in the same spot (i.e. in a
later design, it won't be both the current and "+1.5C" UI elements on
the same clamped point at the extremities).

Visually:
![image](https://user-images.githubusercontent.com/1843555/189810139-d4aa58c4-c36d-4f51-865b-1753bcc63fc6.png)
