### PR TITLE
Change design to v0.61a

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -121,28 +121,30 @@ Sentry.init({
             :zoom-limit-offset="-1"></MapView>
         <div class="map-overlay">
             <div class="container">
-                <section class="primary-content content-section">
-                    <div class="filter-inputs">
-                        <CatastropheToggle class="catastrophe-toggle"
-                            v-model:filter="state.catastropheFilter"
-                            :allCatastrophes="allCatastrophes"
-                            :currentCatastrophesCount="catastrophes.size"></CatastropheToggle>
-                        <!-- TODO: change icon style -->
-                        <RegionSearch class="region-search"
-                            :district="state.district"
-                            @district-selected="selectDistrict"></RegionSearch>
-                    </div>
-                    <Timeline class="timeline" :year="state.year"
-                        @year-selected="selectYear"
-                        :district="state.district"></Timeline>
-                </section>
-                <section class="secondary-content content-section">
-                    <CallToAction class="call-to-action"></CallToAction>
-                    <Thermometer :statistics="selectedStatistics"
-                        :reference-statistics="referenceYearStatistics"
-                        :year="state.year"></Thermometer>
-                    <Header></Header>
-                </section>
+                <div class="content-container">
+                    <section class="primary-content content-section">
+                        <div class="filter-inputs">
+                            <!-- TODO: change icon style -->
+                            <RegionSearch class="region-search"
+                                :district="state.district"
+                                @district-selected="selectDistrict"></RegionSearch>
+                            <CatastropheToggle class="catastrophe-toggle"
+                                v-model:filter="state.catastropheFilter"
+                                :allCatastrophes="allCatastrophes"
+                                :currentCatastrophesCount="catastrophes.size"></CatastropheToggle>
+                        </div>
+                        <Timeline class="timeline" :year="state.year"
+                            @year-selected="selectYear"
+                            :district="state.district"></Timeline>
+                    </section>
+                    <section class="secondary-content content-section">
+                        <Thermometer :statistics="selectedStatistics"
+                            :reference-statistics="referenceYearStatistics"
+                            :year="state.year"></Thermometer>
+                        <CallToAction class="call-to-action"></CallToAction>
+                    </section>
+                </div>
+                <Header class="header"></Header>
             </div>
         </div>
     </div>
@@ -165,6 +167,14 @@ Sentry.init({
     width: 100%;
     height: 100%;
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.content-container {
+    display: flex;
+    min-height: 0;  /* undo min-height: auto from being a flex child */
+    height: 100%;
     flex-direction: row;
     gap: var(--sz-100);
     justify-content: space-between;
@@ -183,8 +193,15 @@ Sentry.init({
 }
 
 .secondary-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--sz-800);
     align-items: center;
-    padding-bottom: var(--sz-400);  /* space for OpenStreetMap attribution */
+}
+
+.header {
+    padding-right: 110px;
 }
 
 .map-overlay {
@@ -195,7 +212,7 @@ Sentry.init({
     width: 100%;
     /* Note: must be this high to be over the overleaf z-index. */
     z-index: 1000;
-    padding: var(--sz-100) var(--sz-100);
+    padding: var(--size-map-padding) var(--sz-100);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -211,8 +228,7 @@ Sentry.init({
     display: flex;
     flex-direction: column;
     justify-content: start;
-    gap: var(--sz-30);
-    position: relative;
+    gap: var(--size-map-controls-gap);
 }
 
 .call-to-action {
@@ -223,21 +239,15 @@ Sentry.init({
     min-height: 0;  /* undo min-height: auto from being a flex child */
     height: 100%;
     width: 100%;
-    position: absolute;
-    z-index: 2;  /* show above search box */
 }
 
 .region-search {
     pointer-events: auto;
     --sz-margin-left: calc(var(--sz-100) + var(--size-map-zoom-control));
-    margin-left: var(--sz-margin-left);
     --vs-selected-color: var(--color-text);
     --vs-border-radius: var(--sz-400);
     --vs-border-color: var(--color-border);
-    --vs-dropdown-max-height: 600%;
-    position: absolute;
-    top: calc(var(--size-map-zoom-control) + var(--sz-30));
-    width: calc(100% - var(--sz-margin-left));
+    --vs-dropdown-max-height: 750%;
 }
 
 .timeline {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -60,6 +60,8 @@
   --color-heading: var(--clr-gris-fonce);
 
   --size-map-zoom-control: 32px;
+  --size-map-controls-gap: var(--sz-30);
+  --size-map-padding: var(--sz-100);
 }
 
 *,

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -3,8 +3,7 @@
         <section class="container">
             <!-- Header row -->
             <PillBadge class="total-count pill" :value="currentCatastrophesCount"></PillBadge>
-            <!-- TODO: dynamic truncation of text -->
-            <div class="title grid-col-span-2"><span>Év. extrêmes</span></div>
+            <div class="title grid-col-span-2"><span>Événements extrêmes</span></div>
             <!-- TODO: hover styling -->
             <button v-if="expanded" @click="expanded = false"><img src="/icons/x.svg"></button>
             <button v-else @click="expanded = true"><img src="/icons/settings.svg"></button>
@@ -166,13 +165,11 @@ export default defineComponent({
 
 .wrapper {
     --expand-transition: 0.5s ease;
-    padding-left: calc(var(--sz-100) + var(--size-map-zoom-control));
     transition: padding-left var(--expand-transition);
     transition: width var(--expand-transition);
 }
 
 .expanded.wrapper {
-    padding-left: 0;
     flex: 1;
 }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,9 +1,9 @@
 <template>
     <header>
         <!-- TODO: proper logo -->
-        <p>terre os</p>
-        <!-- TODO: proper logo -->
         <p>Éqt*x(*)</p>
+        <!-- TODO: proper logo -->
+        <p>terre os</p>
     </header>
 </template>
 
@@ -18,9 +18,10 @@ export default defineComponent({
 <style scoped>
 header {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: space-between;
-    font-size: 24px;  /* TODO: remove, use logos instead */
+    font-size: 18px;  /* TODO: remove, use logos instead */
+    color: var(--clr-blanc);  /* TODO: logo */
 }
 
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -289,7 +289,10 @@ function refreshIcons(icons: MapIcons, catastrophes: List<Catastrophe>, i18n: Co
 .leaflet-left .leaflet-control {
     /* IFCHANGE: change CatastropheToggle */
     margin-left: var(--sz-100);
-    margin-top: var(--sz-100);
+    /* IFCHANGE: change App */
+    /* 2x controls + 2x gaps between other controls and this one, + extra
+       pixels due to 4x 1px borders on the way. */
+    margin-top: calc(var(--size-map-padding) + var(--size-map-zoom-control) * 2 + var(--size-map-controls-gap) * 2 + 4px);
 }
 
 .leaflet-bar a {


### PR DESCRIPTION
Not using the icon next to the catastrophe toggle title for now since it still leads to a multi-line title on the small device and we don't currently have a logo for it.

Visual:
![image](https://user-images.githubusercontent.com/1843555/190042709-b9ee8ea9-a12a-458c-8487-67e9c7a8ec13.png)

Toggled:
![image](https://user-images.githubusercontent.com/1843555/190042722-1aba1487-6716-4cf4-91a2-fe984d849954.png)
