### PR TITLE
Change height to 100% instead of 100vh

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -72,9 +72,13 @@
   position: relative;
 }
 
+html {
+  height: 100%;
+}
+
 body {
   margin: 0;
-  height: 100vh;
+  height: 100%;
   color: var(--color-text);
   background: var(--color-background);
   transition: color 0.5s, background-color 0.5s;


### PR DESCRIPTION
This is to try and address the issue with the scrollbar that appears when viewing on android (with its collapsible URL bar). I think the root cause is covered here:
https://bugs.chromium.org/p/chromium/issues/detail?id=844848#c4 with the recommendation to use 100% height instead. Let's try that.