### PR TITLE
Change la taille par défaut des icones

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,7 +1,7 @@
 @import "./base.css";
 
 :root {
-  --icon-size: 48px;
+  --icon-size: 27px;
 }
 
 #app {


### PR DESCRIPTION
Comme la carte est lancé zoomé out, les icones doivent être plus petites. Par la suite les icones sont resizé normalement. La meilleure solution aurait été de rouler la fonction de calcule de taille dès le début, mais cette solution évite un resize pour rien