### PR TITLE
Show emoji next to current temperature

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,8 +139,7 @@ Sentry.init({
                     </section>
                     <section class="secondary-content content-section">
                         <Thermometer :statistics="selectedStatistics"
-                            :reference-statistics="referenceYearStatistics"
-                            :year="state.year"></Thermometer>
+                            :reference-statistics="referenceYearStatistics"></Thermometer>
                         <CallToAction class="call-to-action"></CallToAction>
                     </section>
                 </div>

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -19,8 +19,8 @@
             </div>
 
             <div class="reference-value pill tracked-reference track-bottom">
-                <span>{{$n(referenceValueDisplayed, 'temperature_no_unit')}}°</span>
                 <span>{{referenceYear}}</span>
+                <span>{{$n(referenceValueDisplayed, 'temperature_no_unit')}}°</span>
             </div>
         </div>
 
@@ -29,11 +29,9 @@
             <div class="line"></div>
         </div>
 
-        <img class="tracked-current track-bottom" :src="emojiPath">
-
         <div class="current-value pill tracked-current track-bottom">
+            <img :src="emojiPath">
             <span>{{$n(currentValueDisplayed, 'temperature_no_unit')}}°</span>
-            <span>{{year}}</span>
         </div>
     </div>
 </template>
@@ -62,11 +60,6 @@ export default defineComponent({
             type: Object as PropType<RegionStatistics>,
             required: true,
         },
-        year: {
-            type: Number,
-            required: true,
-
-        }
     },
     data() {
         return {
@@ -275,14 +268,14 @@ export default defineComponent({
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    line-height: 1.5;
+    line-height: 1.3;
     gap: var(--sz-50);
     color: var(--clr-blanc);
     border-radius: var(--sz-600);
 }
 
 .current-value {
-    min-width: 70px;
+    min-width: 60px;
     border: 2px solid var(--clr-blanc);
     background-color: var(--color-accent);
     font-size: var(--sz-400);
@@ -290,8 +283,13 @@ export default defineComponent({
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 }
 
+.current-value span {
+    flex: 1;
+    text-align: right;
+}
+
 .reference-value {
-    min-width: 60px;
+    min-width: 55px;
     background-color: var(--clr-thermometer-mercury);
     font-size: var(--sz-200);
 }
@@ -318,9 +316,9 @@ export default defineComponent({
 }
 
 img {
+    left: 0;
+    transform: translateX(-50%);
+    min-width: 32px;
     position: absolute;
-    margin-left: var(--sz-stem-width);
-    margin-bottom: var(--sz-400);
-    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
 }
 </style>


### PR DESCRIPTION
Following the updated figma design:
- No longer show current year (no longer need the prop either);
- Swap 1990 year with temperature;
- Increase emoji size

Note that the emoji rescaled looks blurry now. Created a high-priority TODO to replace them (we'll get new ones, too, we can get them at the right size then).

![image](https://user-images.githubusercontent.com/1843555/190317206-01e600d3-6796-4280-8473-27cc39098638.png)
