### PR TITLE
Add size-increase breakpoints (~responsive)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -235,9 +235,10 @@ Sentry.init({
 
 .region-search {
     pointer-events: auto;
+    --vs-font-size: var(--default-font-size);
     --sz-margin-left: calc(var(--sz-100) + var(--size-map-zoom-control));
     --vs-selected-color: var(--color-text);
-    --vs-border-radius: var(--sz-400);
+    --vs-border-radius: var(--border-radius);
     --vs-border-color: var(--color-border);
     --vs-dropdown-max-height: 750%;
 }
@@ -248,7 +249,7 @@ Sentry.init({
     font-weight: var(--fw-regular);
     font-size: var(--sz-400);
     background-color: var(--color-background-accent);
-    border-radius: var(--sz-600);
+    border-radius: var(--border-radius);
     padding: var(--sz-200);
 }
 

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -40,12 +40,58 @@
   --sz-600: 16px;
   --sz-700: 24px;
   --sz-800: 26px;
+  --sz-900: 32px;
 
   /* Font weight variants */
   --fw-regular: 500;
 
   /* Font families */
   --ff-primary: 'Matter';
+}
+
+@media only screen and (min-width: 600px) {
+  :root {
+    --sz-30: 6px;
+    --sz-50: 8px;
+    --sz-100: 10px;
+    --sz-200: 11px;
+    --sz-300: 12px;
+    --sz-400: 14px;
+    --sz-600: 18px;
+    --sz-700: 26px;
+    --sz-800: 28px;
+    --sz-900: 34px;
+  }
+}
+
+@media only screen and (min-width: 900px) {
+  :root {
+    --sz-30: 10px;
+    --sz-50: 12px;
+    --sz-100: 14px;
+    --sz-200: 15px;
+    --sz-300: 16px;
+    --sz-400: 18px;
+    --sz-600: 22px;
+    --sz-700: 30px;
+    --sz-800: 32px;
+    --sz-900: 38px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  :root {
+    --sz-30: 14px;
+    --sz-50: 16px;
+    --sz-100: 18px;
+    --sz-200: 19px;
+    --sz-300: 20px;
+    --sz-400: 22px;
+    --sz-600: 26px;
+    --sz-700: 34px;
+    --sz-800: 36px;
+    --sz-900: 42px;
+  }
 }
 
 /* semantic color variables for this project */
@@ -60,7 +106,11 @@
   --color-text: var(--clr-gris-mi-fonce);
   --color-heading: var(--clr-gris-fonce);
 
-  --size-map-zoom-control: 32px;
+  --default-font-size: var(--sz-400);
+
+  --border-radius: 12px;
+
+  --size-map-zoom-control: var(--sz-900);
   --size-map-controls-gap: var(--sz-30);
   --size-map-padding: var(--sz-100);
 }
@@ -86,7 +136,7 @@ body {
   line-height: 1.1;
   font-family: var(--ff-primary);
   font-weight: var(--fw-regular);
-  font-size: var(--sz-400);
+  font-size: var(--default-font-size);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/components/CallToAction.vue
+++ b/src/components/CallToAction.vue
@@ -16,7 +16,7 @@ a {
     font-size: var(--sz-400);
     color: var(--clr-blanc);
     background-color: var(--color-accent);
-    border-radius: var(--sz-600);
+    border-radius: var(--border-radius);
     width: min-content;
     border: none;
     cursor: pointer;

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="wrapper" :class="{expanded: expanded}">
         <section class="container">
-            <!-- Header row -->
             <header class="row" @click="expanded = !expanded">
                 <PillBadge class="total-count pill" :value="currentCatastrophesCount"></PillBadge>
                 <div class="title grid-col-span-2"><span>Événements extrêmes</span></div>
@@ -169,7 +168,7 @@ export default defineComponent({
 }
 
 .container {
-    border-radius: var(--sz-400);
+    border-radius: var(--border-radius);
     border: 1px solid var(--color-border);
     background-color: var(--color-background);
     padding: 0 var(--sz-100);
@@ -197,7 +196,7 @@ export default defineComponent({
     width: 100%;
     min-height: 1px;
     background-color: var(--clr-beige);
-    border-radius: var(--sz-600);
+    border-radius: var(--border-radius);
 }
 
 button img {
@@ -207,7 +206,7 @@ button img {
 }
 
 .pill {
-    min-width: 34px;
+    min-width: calc(var(--default-font-size) * 3.5);
 }
 
 .catastrophe-icon {

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -17,7 +17,7 @@ input[type="checkbox"] {
     background-color: var(--color-background-accent);
     width: var(--sz-700);
     height: var(--sz-700);
-    border-radius: var(--sz-100);
+    border-radius: 8px;
     box-shadow: 0px var(--sz-30) var(--sz-30)
         rgba(255, 255, 255, 0.04),
         inset 0px -1px 0px rgba(255, 255, 255, 0.66),
@@ -32,7 +32,10 @@ input[type="checkbox"]::before {
     width: var(--sz-700);
     height: var(--sz-700);
     transform-origin: bottom left;
-    background: url("/icons/check.svg")
+    background-image: url("/icons/check.svg");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
 }
 
 input[type="checkbox"]:checked::before {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -286,7 +286,7 @@ function refreshIcons(icons: MapIcons, catastrophes: List<Catastrophe>, i18n: Co
 }
 
 .catastrophe-popup .leaflet-popup-content .list-group-flush {
-    border-radius: 6px;
+    border-radius: var(--border-radius);
 }
 
 .leaflet-touch .leaflet-control-zoom-in,
@@ -316,14 +316,14 @@ function refreshIcons(icons: MapIcons, catastrophes: List<Catastrophe>, i18n: Co
 .leaflet-touch .leaflet-bar a:first-child,
 .leaflet-touch .leaflet-bar {
     /* IFCHANGE: change CatastropheToggle */
-    border-top-left-radius: var(--sz-400);
-    border-top-right-radius: var(--sz-400);
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
 }
 
 .leaflet-touch .leaflet-bar a:last-child,
 .leaflet-touch .leaflet-bar {
-    border-bottom-left-radius: var(--sz-400);
-    border-bottom-right-radius: var(--sz-400);
+    border-bottom-left-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
 }
 
 .leaflet-touch .leaflet-bar {

--- a/src/components/PillBadge.vue
+++ b/src/components/PillBadge.vue
@@ -17,7 +17,7 @@ export default defineComponent({
 <style scoped>
 div {
     display: inline;
-    border-radius: var(--sz-400);
+    border-radius: var(--border-radius);
     font-size: var(--sz-400);
     color: var(--clr-blanc);
     background-color: var(--color-accent);

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -171,7 +171,7 @@ export default defineComponent({
     --notch-offset: 10%;
     /* the highest notch is this much % higher than notch-offset */
     --notch-height: 85%;
-    --sz-bulb: 32px;
+    --sz-bulb: var(--sz-900);
     /* limit values where we start clamping */
     --notch-min: var(--sz-bulb) / 2;
     --notch-max: 100%;
@@ -195,7 +195,7 @@ export default defineComponent({
     height: 100%;
     border: var(--sz-stem-border) solid var(--clr-thermometer-border);
     background-color: var(--clr-thermometer-background);
-    border-radius: var(--sz-600);
+    border-radius: var(--border-radius);
     overflow: hidden;
 }
 
@@ -271,7 +271,7 @@ export default defineComponent({
     line-height: 1.3;
     gap: var(--sz-50);
     color: var(--clr-blanc);
-    border-radius: var(--sz-600);
+    border-radius: var(--border-radius);
 }
 
 .current-value {
@@ -318,7 +318,7 @@ export default defineComponent({
 img {
     left: 0;
     transform: translateX(-50%);
-    min-width: 32px;
+    min-width: var(--sz-900);
     position: absolute;
 }
 </style>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -227,7 +227,7 @@ export default defineComponent({
 .vue-slider .vue-slider-dot-tooltip-inner.vue-slider-dot-tooltip-inner-top{
     top: -11px; 
     padding: 2px 10px; 
-    border-radius: 14px
+    border-radius: var(--border-radius);
 }
 
 .vue-slider .vue-slider-process.prevision-indicator {    


### PR DESCRIPTION
Changes the `--sz-...` CSS variables at various breakpoints, so that the fonts and spacing increases with larger devices. A deliberate desktop design would be better, but this makes it a bit more usable in the meantime IMO.

Picked breakpoints based on:
https://www.freecodecamp.org/news/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862/

Some other changes (/bug-fixes) were made(/discovered) while doing this:
- border-radius is fixed, it gets its own CSS var (+ use it everywhere);
- thermometer bulb uses a sz var to be dynamic, same for zoom controls;
- emojis uses a sz var to be dynamic;
- pill min-width gets a dynamic value based on css vars, not hardcoded;
- checkbox image now stretches to full width/height;

TODOs:
- The timeline should be made a bit more responsive to be able to grow similarly, but it is tricky as-is to get it visually nice and probably worth its own PR.
- We should set some max-widths on some elements (e.g. input elements) so that it looks bit nicer on desktop, maybe some left-right padding too?

---

Here are what the different breakpoints look like now.

## mobile (<600px)
![image](https://user-images.githubusercontent.com/1843555/190325916-b0efe11c-d410-418f-b27d-e8203300e008.png)

## tablet portrait (<900px)
![image](https://user-images.githubusercontent.com/1843555/190326017-4c3914f8-d9a9-476f-80a6-f5e1616061c8.png)

## tablet landscape (<1200px)
![image](https://user-images.githubusercontent.com/1843555/190326214-bbd1cea9-e36e-40d5-a032-4ec6ec9d67fe.png)

## desktop (>= 1200px)
![image](https://user-images.githubusercontent.com/1843555/190326294-eacde689-f923-40c0-9ad7-c83ea374feec.png)


