### PR TITLE
Bornes moins brutales.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@ import { useCatastropheStore } from "./stores/catastrophes";
 import { useStatisticStore } from "./stores/statistics";
 import { FILTER_ALL_CATASTROPHES, Catastrophe } from "./models/catastrophes";
 import { REFERENCE_YEAR } from "./models/constants";
-import { DEFAULT_USER_STATE, UserState } from "./models/user";
+import { DEFAULT_USER_STATE } from "./models/user";
 import CallToAction from './components/CallToAction.vue';
 import CatastropheToggle from "./components/CatastropheToggle.vue";
 import Header from "./components/Header.vue";

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,9 @@
 import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from "./catastrophes";
 import { CURRENT_YEAR } from "./constants";
 
+export const MIN_ZOOM = 5;
+export const MAX_ZOOM = 15;
+
 export interface UserState {
     district: number;
     year: number;
@@ -13,6 +16,6 @@ export const DEFAULT_USER_STATE: UserState = {
     district: 0,
     year: CURRENT_YEAR,
     catastropheFilter: FILTER_ALL_CATASTROPHES,
-    location: [45.5001, -73.5679],
-    zoom: 0
+    location: [55.15, -68.30],
+    zoom: MIN_ZOOM
 };


### PR DESCRIPTION
Ajustement des coordonnées initiaux (zoom et position) pour éviter de se faire brusquement recentrer au chargement, et augmentation du padding autour du Québec pour ne pas avoir une timeline dans le chemin systématiquement.