### PR TITLE
Set letter-spacing & fix region-search overflow

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -138,6 +138,7 @@ body {
   font-weight: var(--fw-regular);
   font-size: var(--default-font-size);
   text-rendering: optimizeLegibility;
+  letter-spacing: -0.3px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -188,7 +188,6 @@ export default defineComponent({
 
 .title, .catastrophe-name {
     flex: 1;
-    letter-spacing: -0.3px;
 }
 
 .separator {

--- a/src/components/RegionSearch.vue
+++ b/src/components/RegionSearch.vue
@@ -41,3 +41,11 @@ export default defineComponent({
     }
 })
 </script>
+
+<style>  /* global */
+.v-select .vs__selected-options {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
Based on the two suggestions here:
 - https://github.com/sagalbot/vue-select/issues/754#issuecomment-478364305
 - https://github.com/sagalbot/vue-select/issues/754#issuecomment-501330706

Also adjust letter-spacing to match figma design, this overall makes this issue a lot less common in the first place, but for some regions like "Rouyn-Noranda-Témiscamingue" the overflow fix is still useful.

On 320x450, before:
![image](https://user-images.githubusercontent.com/1843555/190828934-8200d43f-1a35-437b-a8a3-6f9c9de6aa73.png)

After:
![image](https://user-images.githubusercontent.com/1843555/190828956-c0438ea4-5d5a-46e7-a7ce-745fef10272c.png)
