### PR TITLE
Add max-widths for inputs & timeline

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -200,7 +200,7 @@ Sentry.init({
     width: 100%;
     /* Note: must be this high to be over the overleaf z-index. */
     z-index: 1000;
-    padding: var(--size-map-padding) var(--sz-100);
+    padding: var(--size-map-padding);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -213,6 +213,7 @@ Sentry.init({
     width: 100%;
     min-height: 0;  /* don't expand to children content -- undo auto min-height */
     max-height: 100%;
+    max-width: 600px;
     display: flex;
     flex-direction: column;
     justify-content: start;
@@ -247,6 +248,7 @@ Sentry.init({
     background-color: var(--color-background-accent);
     border-radius: var(--border-radius);
     padding: var(--sz-200);
+    max-width: 1280px;
 }
 
 .loading-overlay {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -295,8 +295,7 @@ function updateMapBounds(map: L.Map, mapLayer: L.GeoJSON) {
 }
 
 .leaflet-left .leaflet-control {
-    /* IFCHANGE: change CatastropheToggle */
-    margin-left: var(--sz-100);
+    margin-left: var(--size-map-padding);
     /* IFCHANGE: change App */
     /* 2x controls + 2x gaps between other controls and this one, + extra
        pixels due to 4x 1px borders on the way. */


### PR DESCRIPTION
This makes it look a bit better on desktop IMO:
![image](https://user-images.githubusercontent.com/1843555/190832492-d0ede821-fceb-47fc-b421-2a86aaaf24a2.png)

Especially on a bigger screen:
![image](https://user-images.githubusercontent.com/1843555/190832506-2443f6f6-8cbf-47ab-8740-62dd5e0f9c08.png)
