### PR TITLE
Premier jet d'une fenêtre d'à propos

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,17 +18,24 @@ import RegionSearch from "./components/RegionSearch.vue";
 import Thermometer from './components/Thermometer.vue';
 import Timeline from "./components/Timeline.vue";
 import { useMapStore } from "./stores/map";
+import About from "./components/About.vue";
 
 export default defineComponent({
     components: {
-        CallToAction,
-        CatastropheToggle,
-        Header,
-        LoadingSpinner,
-        MapView,
-        RegionSearch,
-        Thermometer,
-        Timeline,
+    CallToAction,
+    CatastropheToggle,
+    Header,
+    LoadingSpinner,
+    MapView,
+    RegionSearch,
+    Thermometer,
+    Timeline,
+    About
+},
+    data() {
+        return {
+            showAbout: false
+        };
     },
     methods: {
         selectDistrict(id: number) {
@@ -133,9 +140,10 @@ Sentry.init({
                         <CallToAction class="call-to-action"></CallToAction>
                     </section>
                 </div>
-                <Header class="header"></Header>
+                <Header class="header" @about-requested="showAbout = true"></Header>
             </div>
         </div>
+        <About :show-modal="showAbout" @modal-closed="showAbout = false"></About>
     </div>
 
     <div v-if="!loadingCompleted" class="loading-overlay">

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -152,3 +152,11 @@ button, input[type="submit"], input[type="reset"] {
   cursor: pointer;
   outline: inherit;
 }
+
+a {
+  color: var(--color-text);
+}
+
+a:hover {
+  color: var(--clr-gris-moyen);
+}

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -1,0 +1,147 @@
+<template>
+    <div id="modal-container" :style="{ display: showModal ? 'block' : 'none' }" @click="closeModal">
+        <div id="modal-wrapper">
+            <div id="modal" @click="ev => ev.stopPropagation()">
+                <div id="modal-header">
+                    <h1>terreOS</h1>
+                    <div id="close-button-wrapper">
+                        <button id="close-button" @click="closeModal">✕</button>
+                    </div>
+                </div>
+                <div id="modal-content">
+                    <h1>Équiterre</h1>
+                    <div class="lighter">✕</div>
+                    <h1>bleuet.design</h1>
+                    <div class="progs">
+                        <div><a href="https://twitter.com/Drahakar" target="_blank">Andy Emond</a></div>
+                        <div><a href="https://twitter.com/edemartel" target="_blank">Etienne de Martel</a></div>
+                        <div><a href="https://twitter.com/JesseEmond" target="_blank">Jesse Emond</a></div>
+                    </div>
+                    <div v-t="'made_with_love'" class="desc"></div>
+                    <i18n-t keypath="data_source" tag="div" class="desc">
+                        <a v-t="'ouranos'" :href="$t('url_ouranos')" target="_blank"></a>
+                        <a v-t="'qc_govt'" :href="$t('url_qc_govt')" target="_blank"></a>
+                        <a v-t="'can_govt'" :href="$t('url_can_govt')" target="_blank"></a>
+                    </i18n-t>
+                    <div id="version-info">
+                        <div>2022</div>
+                        <div>v1.0</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    emits: ['modal-closed'],
+    props: {
+        showModal: {
+            type: Boolean,
+            default: false
+        }
+    },
+    methods: {
+        closeModal() {
+            this.$emit('modal-closed');
+        }
+    }
+})
+</script>
+
+<style scoped>
+#modal-container {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 10000;
+}
+
+#modal-wrapper {    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+#modal {
+    width: 50%;
+    background-color: var(--clr-beige);
+    overflow: hidden;
+    border-radius: var(--border-radius);
+    box-shadow: 0 3px var(--sz-30) rgba(0, 0, 0, 0.4);
+}
+
+.progs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sz-30);
+    margin-top: var(--sz-700);
+    margin-bottom: var(--sz-700);
+    font-size: var(--sz-600);
+}
+
+#close-button-wrapper {
+    position: absolute;
+    top: 0;
+    right: var(--sz-30);
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+#close-button {
+    background-color: var(--clr-orange);
+    color: var(--clr-blanc);
+    width: var(--sz-700);
+    height: var(--sz-700);
+    border-radius: calc(var(--sz-700) / 2);
+    font-weight: bold;
+    font-size: var(--sz-300);
+    text-align: center;
+}
+
+#modal-header {
+    padding: var(--sz-30);
+    background-color: var(--clr-blanc);
+}
+
+#modal-header h1 {
+    text-align: center;    
+}
+
+#modal-content {
+    padding: var(--sz-600);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.lighter {
+    color: var(--clr-gris-pale);
+    font-size: var(--sz-300);
+    font-weight: bold;
+    margin-top: var(--sz-50);
+    margin-bottom: var(--sz-50);
+}
+
+.desc {
+    margin-bottom: var(--sz-600);
+}
+
+#version-info {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    color: var(--clr-gris-pale);
+}
+</style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
     <header>
-        <p>Éqt*x(*)</p>
-        <p>terre os</p>
+        <button @click="about">Éqt*x(*)</button>
+        <button @click="about">terre os</button>
     </header>
 </template>
 
@@ -10,7 +10,13 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-})
+    emits: ['about-requested'],
+    methods: {
+        about() {
+            this.$emit('about-requested');
+        }
+    }
+});
 </script>
 
 <style scoped>
@@ -21,6 +27,7 @@ header {
     font-size: 18px;
     color: var(--clr-blanc);
 }
-
-
+button {
+    pointer-events: auto;
+}
 </style>

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -164,4 +164,14 @@ export default {
 
     // Timeline
     research_year: "Température / année",
+
+    // About
+    made_with_love: "Le logiciel terreOS a été conçu avec amour grâce à une collaboration entre Équiterre, Bleuet Design ainsi que trois programmeurs bénévoles.",
+    data_source: "Les données utilisées dans ce logiciel proviennent du {0}, du {1} ainsi que du {2}.",
+    ouranos: "consortium Ouranos",
+    url_ouranos: "https://www.ouranos.ca/",
+    qc_govt: "Gouvernement du Québec",
+    url_qc_govt: "https://donneesquebec.ca/",
+    can_govt: "Gouvernement du Canada",
+    url_can_govt: "https://www.canada.ca/fr/environnement-changement-climatique/services/changements-climatiques/centre-canadien-services-climatiques.html"
 };


### PR DESCRIPTION
Premier jet parce qu'il manque les logos, faque en attendant j'ai utilisé des titres h1 comme placeholders.
![image](https://user-images.githubusercontent.com/4632802/190833385-de37b637-e7a7-4bfa-8096-00bb217f9fd2.png)

Pour ouvrir, cliquez sur terreOS ou le équi*censuré en bas de l'écran.