### PR TITLE
Ne pas changer la sélection si un popup est ouvert.

### DIFF
--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -66,6 +66,7 @@ export function createMapMarker(group: CatastropheGroup, appContext: AppContext)
         closeButton: false,
         minWidth: 500,
         maxHeight: 400,
+        closeOnClick: false
     });
     popup.setContent(() => {
         const div = document.createElement('div');


### PR DESCRIPTION
Ceci implique de désactiver le "close on click" sur un popup et de gérer la situation nous même: lorsqu'on clique sur une région ou sur la carte, si un popup est ouvert quelque part, on le ferme, et on bloque ensuite l'événement.