### PR TITLE
Show 'C' unit with absolute temperatures

### DIFF
--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -22,7 +22,7 @@
 
             <div class="reference-value pill tracked-reference track-bottom">
                 <span>{{referenceYear}}</span>
-                <span>{{$n(referenceValueDisplayed, 'temperature_no_unit')}}°</span>
+                <span>{{$n(referenceValueDisplayed, 'temperature')}}</span>
             </div>
         </div>
 
@@ -33,7 +33,7 @@
 
         <div class="current-value pill tracked-current track-bottom">
             <img :src="emojiPath">
-            <span>{{$n(currentValueDisplayed, 'temperature_no_unit')}}°</span>
+            <span>{{$n(currentValueDisplayed, 'temperature')}}</span>
         </div>
     </div>
 </template>

--- a/src/locales/formats.ts
+++ b/src/locales/formats.ts
@@ -7,10 +7,6 @@ export const numberFormats = {
         minimumFractionDigits: 1,
         maximumFractionDigits: 1,
     },
-    temperature_no_unit: {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 1,
-    },
     temperature_delta_no_unit: {
         signDisplay: 'exceptZero',
         minimumFractionDigits: 1,


### PR DESCRIPTION
When showing to users, it wasn't immediately clear that this was showing Celsius temperatures. Hopefully `°C` makes that very clear.

![image](https://user-images.githubusercontent.com/1843555/190874324-dcfe4bb5-08a9-4e8b-999e-b62b429541cf.png)
