### PR TITLE
Fix box-sizing typo for pills, drive-by fix icon in title

### DIFF
--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -3,7 +3,7 @@
         <section class="container">
             <header class="row" @click="expanded = !expanded">
                 <PillBadge class="total-count pill" :value="currentCatastrophesCount"></PillBadge>
-                <img class="catastrophe-icon" src="/icons/attention-highlight.png">
+                <img class="catastrophe-icon" src="/icons/attention-red.png">
                 <div class="title"><span>Événements extrêmes</span></div>
                 <button v-if="expanded"><img src="/icons/x.svg"></button>
                 <button v-else><img src="/icons/settings.svg"></button>
@@ -206,7 +206,7 @@ button img {
 }
 
 .pill {
-    box-sixing: content-box;
+    box-sizing: content-box;
     min-width: 3ch;
 }
 


### PR DESCRIPTION
My bad, I borked the file rename in https://github.com/Drahakar/vireauvert/pull/163

![image](https://user-images.githubusercontent.com/1843555/190874468-674f7f45-3368-4f56-8bc4-e11b4c85bc82.png)
