### PR TITLE
Make 'about' modal larger on mobile only

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -44,6 +44,7 @@
 
   /* Sizes that change at certain breakpoints */
   --timeline-horizontal-padding: var(--sz-200);
+  --modal-width: 75%;
 
   /* Font weight variants */
   --fw-regular: 500;
@@ -66,6 +67,7 @@
     --sz-900: 34px;
 
     --timeline-horizontal-padding: var(--sz-600);
+    --modal-width: 50%;
   }
 }
 

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -73,7 +73,7 @@ export default defineComponent({
 }
 
 #modal {
-    width: 50%;
+    width: var(--modal-width);
     background-color: var(--clr-beige);
     overflow: hidden;
     border-radius: var(--border-radius);


### PR DESCRIPTION
It felt a bit narrow on mobile at 50%, but for other sizes it's perfect.

Before:
![image](https://user-images.githubusercontent.com/1843555/190874858-2328b2bf-bf50-4519-b9b5-9bdf71fcc6e2.png)

After:
![image](https://user-images.githubusercontent.com/1843555/190874870-fed8c56b-6ed0-4236-9eac-3dd28377d5a7.png)


And desktop etc. is left unchanged.