### PR TITLE
Rendement de certaines zones cachées de la carte.

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -182,6 +182,7 @@ export default defineComponent({
                 bounceAtZoomLimits: false,
                 maxBoundsViscosity: 1
             });
+            map.getRenderer(map as any).options.padding = 0.5;
             L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
             }).addTo(map);


### PR DESCRIPTION
Utilisation d'une feature semi-documentée de Leaflet qui consiste à ajouter un "padding" au renderer. Je l'ai mis à 0.5, ce qui veut dire que la zone dessinée par le renderer va être 50% plus grande que la zone affichable de la carte, avec pour effet de "prefetch" les tuiles juste en dehors de celle-ci.

Le résultat est qu'on voit beaucoup moins de situation ou les polygones de la carte électorale ou du masque apparaître en retard durant le panning.