### PR TITLE
Re-use tutorial width on map popups

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -47,7 +47,7 @@
   /* Sizes that change at certain breakpoints */
   --timeline-horizontal-padding: var(--sz-200);
   --modal-width: 75%;
-  --tutorial-width: 216px;
+  --popup-width: 216px;
 
   /* Font weight variants */
   --fw-regular: 500;
@@ -71,7 +71,7 @@
 
     --timeline-horizontal-padding: var(--sz-600);
     --modal-width: 50%;
-    --tutorial-width: 256px;
+    --popup-width: 256px;
   }
 }
 
@@ -88,7 +88,7 @@
     --sz-800: 32px;
     --sz-900: 38px;
 
-    --tutorial-width: 332px;
+    --popup-width: 332px;
   }
 }
 
@@ -106,7 +106,7 @@
     --sz-900: 48px;
 
     --timeline-horizontal-padding: var(--sz-700);
-    --tutorial-width: 456px;
+    --popup-width: 456px;
   }
 }
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,8 +1,6 @@
 <template>
     <div id="wrapper" ref="mapWrapper">
-        <keep-alive>
-            <div class="map" ref="mapElement"></div>
-        </keep-alive>
+        <div class="map" ref="mapElement"></div>
     </div>
 </template>
 
@@ -323,6 +321,7 @@ function updateMapBounds(map: L.Map, mapLayer: L.GeoJSON) {
 
 .catastrophe-popup .leaflet-popup-content {
     margin: 0;
+    min-width: var(--popup-width);
 }
 
 .catastrophe-popup .leaflet-popup-content .list-group-flush {

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -128,7 +128,7 @@ export default defineComponent({
     background-color: var(--color-background-accent);
     color: var(--clr-gris-moyen);
     border-radius: var(--border-radius);
-    max-width: var(--tutorial-width);
+    max-width: var(--popup-width);
     font-size: var(--sz-300);
     box-shadow: 0px 4px 4px rgba(53, 53, 53, 0.25);
 }

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -73,8 +73,6 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
     const popup = L.popup({
         className: 'catastrophe-popup',
         closeButton: false,
-        minWidth: 500,
-        maxHeight: 400,
         closeOnClick: false,
     });
     popup.setContent(() => {


### PR DESCRIPTION
This fixes the issue where the popups are too big on mobile. It looks like it's okay to not set the min width/height in the helper? Please correct me if I'm wrong.

![image](https://user-images.githubusercontent.com/1843555/190948349-3399abb4-e577-4b57-b64e-ee3da4343f03.png)
