### PR TITLE
C'est pip, pas npm, laule

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 Les outils nécessitent Python 3.10 minimum.
 
 Pour installer les dépendances, exécutez dans ce répertoire:
-```npm install -r requirements.txt```
+```pip install -r requirements.txt```
 
 Les scripts sont tous conçus pour être exécutables tel quel sans avoir à spécifier de paramètre en ligne de commande ou de variable d'environnement.


### PR DESCRIPTION
Mais c'est correct parce que @Drahakar l'a reviewé pis s'en est pas rendu compte donc je me distance de tout blâme.