### PR TITLE
Opinionated timeline changes prior to fixing 2050/2100 issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -186,6 +186,7 @@ Sentry.init({
     min-height: 0;  /* undo min-height: auto from being a flex child */
     height: 100%;
     flex-direction: row;
+    gap: var(--app-column-gap);
     justify-content: space-between;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -186,7 +186,6 @@ Sentry.init({
     min-height: 0;  /* undo min-height: auto from being a flex child */
     height: 100%;
     flex-direction: row;
-    gap: var(--sz-100);
     justify-content: space-between;
 }
 

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -45,6 +45,7 @@
   --sz-900: 32px;
 
   /* Sizes that change at certain breakpoints */
+  --app-column-gap: 0;
   --timeline-horizontal-padding: var(--sz-200);
   --modal-width: 75%;
   --tutorial-width: 216px;
@@ -69,6 +70,7 @@
     --sz-800: 28px;
     --sz-900: 34px;
 
+    --app-column-gap: var(--sz-100);
     --timeline-horizontal-padding: var(--sz-600);
     --modal-width: 50%;
     --tutorial-width: 256px;

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -11,7 +11,8 @@
                     :chart-options="catastropheOptions" />
             </div>
             <div class="slider-container" ref="sliderContainer">
-                <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years" :marks="marks" :adsorb="true">
+                <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years"
+                    :marks="marks" :adsorb="true" drag-on-click="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -297,6 +297,7 @@ export default defineComponent({
 }
 
 .timeline-container {
+    /* Undo the timeline component padding to push to the left side */
     margin-left: calc(0px - var(--timeline-horizontal-padding));
 }
 

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -11,7 +11,7 @@
                     :chart-options="catastropheOptions" />
             </div>
             <div class="slider-container" ref="sliderContainer">
-                <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years" :marks="marks" :adsorb="false">
+                <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years" :marks="marks" :adsorb="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -2,33 +2,35 @@
     <div class="timeline">
         <div id="slidertitle" v-t="`timeline_mode_${mode}`">
         </div>
-        <div id="timelinegraph">
-            <!-- set width to 0 to let it auto-size it with given height. -->
-            <Line v-if="mode === TimelineMode.Temperature" :chart-data="temperatureData" :height="90" :width="0"
-                :chart-options="temperatureOptions" />
-            <Bar v-if="mode === TimelineMode.CatastropheCount" :chart-data="catastropheData" :height="90" :width="0"
-                :chart-options="catastropheOptions" />
-        </div>
-        <div id="slidercontainer" ref="sliderContainer">
-            <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years" :marks="marks" :adsorb="false">
-                <template v-slot:label="{value}">
-                    <div class="markline"></div>
-                    <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>
-                </template>
-                <template v-slot:step="{ active }">
-                    <div :class="['vue-slider-mark-step', {'vue-slider-mark-step-active': active}]"></div>
-                </template>
-                <template v-slot:tooltip="{ value }">
-                    <div class="vue-slider-dot-tooltip-inner vue-slider-dot-tooltip-inner-top"
-                        data-tutorial-step="year-selector">
-                        <span class="vue-slider-dot-tooltip-text">{{ value }}</span>
-                    </div>
-                    <div class="tooltip-line"></div>
-                </template>
-                <template v-slot:dot>
-                    <TimelineArrow class="slider-arrow"></TimelineArrow>
-                </template>
-            </vue-slider>
+        <div class="timeline-container">
+            <div class="timeline-graph">
+                <!-- set width to 0 to let it auto-size it with given height. -->
+                <Line v-if="mode === TimelineMode.Temperature" :chart-data="temperatureData" :height="90" :width="0"
+                    :chart-options="temperatureOptions" />
+                <Bar v-if="mode === TimelineMode.CatastropheCount" :chart-data="catastropheData" :height="90" :width="0"
+                    :chart-options="catastropheOptions" />
+            </div>
+            <div class="slider-container" ref="sliderContainer">
+                <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years" :marks="marks" :adsorb="false">
+                    <template v-slot:label="{value}">
+                        <div class="markline"></div>
+                        <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>
+                    </template>
+                    <template v-slot:step="{ active }">
+                        <div :class="['vue-slider-mark-step', {'vue-slider-mark-step-active': active}]"></div>
+                    </template>
+                    <template v-slot:tooltip="{ value }">
+                        <div class="vue-slider-dot-tooltip-inner vue-slider-dot-tooltip-inner-top"
+                            data-tutorial-step="year-selector">
+                            <span class="vue-slider-dot-tooltip-text">{{ value }}</span>
+                        </div>
+                        <div class="tooltip-line"></div>
+                    </template>
+                    <template v-slot:dot>
+                        <TimelineArrow class="slider-arrow"></TimelineArrow>
+                    </template>
+                </vue-slider>
+            </div>
         </div>
         <div id="mode-container">
             <div class="item" v-for="value of Object.values(TimelineMode)" :title="$t(`timeline_mode_${value}`)">
@@ -235,14 +237,14 @@ export default defineComponent({
     margin-bottom: var(--sz-50);
 }
 
-#slidercontainer input {
+.slider-container input {
     -webkit-appearance: none;
     background: #ffffff;
     outline: none;
     opacity: 1;
 }
 
-#slidercontainer {
+.slider-container {
     margin-bottom: var(--sz-100);
 }
 
@@ -295,6 +297,10 @@ export default defineComponent({
 
 .timeline {
     padding: var(--sz-50) var(--timeline-horizontal-padding);
+}
+
+.timeline-container {
+    margin-left: calc(0px - var(--timeline-horizontal-padding));
 }
 
 @media screen and (min-width: 768px) {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -47,7 +47,7 @@
 
 <script lang="ts">
 import VueSlider from 'vue-slider-component'
-import { Map } from 'immutable';
+import { Map, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
 import { TIMELINE_YEARS, BEGIN_MODELED_YEAR } from '@/models/constants';
@@ -102,7 +102,7 @@ export default defineComponent({
                 sliderContainer.value.style.marginLeft = `${axis.width}px`;
             }
         };
-        const baseOptions = Map({
+        const baseOptions = Map(fromJS({
             onClick: (e: ChartEvent, tooltipItems: ActiveElement[], chart: ChartJS) => {
                 const canvasPosition = getRelativePosition(e, chart)
                 const yearId = chart.scales.x.getValueForPixel(canvasPosition.x);
@@ -140,9 +140,9 @@ export default defineComponent({
             },
             responsive: true,
             maintainAspectRatio: false,
-        });
+        }));
 
-        const temperatureOptions = baseOptions.mergeDeep(Map({
+        const temperatureOptions = baseOptions.mergeDeep(Map(fromJS({
             scales: {
                 y: {
                     ticks: {
@@ -151,9 +151,9 @@ export default defineComponent({
                     }
                 },
             },
-        })).toObject() as ChartOptions<'line'>;
+        }))).toJS() as ChartOptions<'line'>;
 
-        const catastropheOptions = baseOptions.mergeDeep(Map({
+        const catastropheOptions = baseOptions.mergeDeep(Map(fromJS({
             scales: {
                 y: {
                     ticks: {
@@ -161,7 +161,7 @@ export default defineComponent({
                     }
                 },
             },
-        })).toObject() as ChartOptions<'bar'>;
+        }))).toJS() as ChartOptions<'bar'>;
 
         return {
             selectedYear,

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -60,6 +60,7 @@ import { Chart as ChartJS, ChartEvent, ActiveElement, Title, Tooltip, Legend, Ba
 import { numberFormats } from '@/locales/formats';
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PointElement, LineElement, Filler)
+ChartJS.defaults.font.family = "Matter";
 
 enum TimelineMode {
     Temperature = "Temperature",

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -12,7 +12,7 @@
             </div>
             <div class="slider-container" ref="sliderContainer">
                 <vue-slider v-model="selectedYear" :tooltip="'always'" :data="years"
-                    :marks="marks" :adsorb="true" drag-on-click="true">
+                    :marks="marks" :adsorb="true" :drag-on-click="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>


### PR DESCRIPTION
Most of these are with the optics of giving more space for the timeline on mobile, but others are some refactorings/changes as I get familiar with the timeline component.
- For mobile only, remove the gap between 2-column layout (gap looks large next to call-to-action button);
- Push the chart & slider to the left side. This still leaves space for a toggle button later, makes more space for the timeline;
- Change the chart base options to have all the shared options, with a merge (with immutable JS) on just the fields that are chart-specific;
- Change the ChartJS default font to be `Matter`;
- Set `adsorb` to true on the slider, to make it snap to year values -- otherwise it is "difficult" to change one year at a time, I feel like I have to drag pixel-by-pixel, while the adsorb behavior makes it clearer IMO;
- Set `drag-on-click` on the slider, so that you can start clicking+dragging from a different year. It feels more intuitive to be able to do that IMO. It's not ideal that it doesn't work if you do the same on the chart (since we hook on `onClick`, and there's no mousedown option), so I created a nice-to-have TODO to support that too.

![image](https://user-images.githubusercontent.com/1843555/191126207-24552cd8-a891-4b65-b8ee-8a0ef5f9e3ea.png)
