### PR TITLE
Ajustement d'icônes

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -16,6 +16,9 @@
   margin-top: calc(var(--icon-size) / -2);
   margin-left: calc(var(--icon-size) / -2);
   background-size: var(--icon-size) var(--icon-size);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
   opacity: 0.9;
 }
 
@@ -25,6 +28,9 @@
   margin-top: calc(var(--big-icon-size) / -2);
   margin-left: calc(var(--big-icon-size) / -2);
   background-size: var(--big-icon-size) var(--big-icon-size);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
   
   border: 2px solid white;
   border-radius:50%;

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -19,7 +19,6 @@
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-position: center;
-  opacity: 0.9;
 }
 
 .big-map-icon {

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -98,6 +98,6 @@ export function createHighlightMarker(highlight: Highlight, appContext: AppConte
 export function setGlobalIconSize(ratio: number) {
     const root: HTMLElement | null = document.querySelector(':root');
     if (root) {
-        root.style.setProperty('--icon-size', `${(ratio * 48).toFixed(0)}px`);
+        root.style.setProperty('--icon-size', `${(ratio * 36).toFixed(0)}px`);
     }
 }


### PR DESCRIPTION
- Pas de transparence ever pour des raisons de perf
- Icônes plus petits
- Forcé le background d'un icône à être centré pour éviter des cas ou il apparaît décalé sur Safari.

![image](https://user-images.githubusercontent.com/4632802/191128517-8f302dd3-60bf-4203-986b-686e62e1d2d0.png)
