### PR TITLE
Vente de feu sur les popups et icônes

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3,7 +3,6 @@
 :root {
   --icon-size: 27px;
   --big-icon-size: calc(var(--icon-size) * 2);
-  --popup-border-radius: 12px;
 }
 
 #app {
@@ -109,16 +108,17 @@
 }
 .catastrophe-popup .leaflet-popup-content-wrapper {
   background-color: transparent;
+  border-radius: var(--border-radius);
 }
 
 .popup-content-container {
-  border-radius: var(--popup-border-radius);
+  border-radius: var(--border-radius);
 }
 
 .catastrophe-popup .leaflet-popup-content {
   background-color: var(--clr-beige);
   color: var(--clr-gris-fonce);
-  border-radius: var(--popup-border-radius);
+  border-radius: var(--border-radius);
 }
 
 .leaflet-container a.leaflet-popup-close-button {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -120,3 +120,28 @@
   color: var(--clr-gris-fonce);
   border-radius: var(--popup-border-radius);
 }
+
+.leaflet-container a.leaflet-popup-close-button {
+  width: var(--sz-700);
+  height: var(--sz-700);
+  border-radius: 50%;
+  background-color: var(--clr-gris-pale);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: calc((var(--sz-900) - var(--sz-700)) / 2);
+  margin-top: calc((var(--sz-900) - var(--sz-700)) / 2);
+}
+
+.leaflet-container a.leaflet-popup-close-button span {
+  display: block;
+  font-family: "Matter";
+  color: var( --clr-blanc);
+  font-size: var(--sz-600);
+  line-height: var(--sz-600);
+  width: var(--sz-600);
+  height: var(--sz-600);
+}
+.leaflet-container a.leaflet-popup-close-button:hover span {  
+  color: var(--clr-gris-moyen);
+}

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -128,7 +128,7 @@
 
 .leaflet-container a.leaflet-popup-close-button span {
   display: block;
-  font-family: "Matter";
+  font-family: var(--ff-primary);
   color: var( --clr-blanc);
   font-size: var(--sz-600);
   line-height: var(--sz-600);

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -68,31 +68,24 @@
 .catastrophe-icon-flood {
   background-image: url('/icons/flood.png');
 }
-
 .catastrophe-icon-forest_fire {
   background-image: url('/icons/forest_fire.png');
 }
-
 .catastrophe-icon-freezing_rain {
   background-image: url('/icons/freezing_rain.png');
 }
-
 .catastrophe-icon-heat_wave {
   background-image: url('/icons/heat_wave.png');
 }
-
 .catastrophe-icon-storm_winds {
   background-image: url('/icons/storm_winds.png');
 }
-
 .catastrophe-icon-tornado {
   background-image: url('/icons/tornado.png');
 }
-
 .catastrophe-icon-violent_storm {
   background-image: url('/icons/violent_storm.png');
 }
-
 .catastrophe-icon-winter_storm {
   background-image: url('/icons/winter_storm.png');
 }
@@ -144,4 +137,8 @@
 }
 .leaflet-container a.leaflet-popup-close-button:hover span {  
   color: var(--clr-gris-moyen);
+}
+
+.catastrophe-popup .leaflet-popup-tip {
+  background-color: var(--clr-beige);
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3,6 +3,7 @@
 :root {
   --icon-size: 27px;
   --big-icon-size: calc(var(--icon-size) * 2);
+  --popup-border-radius: 12px;
 }
 
 #app {
@@ -15,7 +16,7 @@
   height: var(--icon-size);
   margin-top: calc(var(--icon-size) / -2);
   margin-left: calc(var(--icon-size) / -2);
-  background-size: var(--icon-size) var(--icon-size);
+  background-size: var(--icon-size);
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-position: center;
@@ -26,7 +27,7 @@
   height: var(--big-icon-size);
   margin-top: calc(var(--big-icon-size) / -2);
   margin-left: calc(var(--big-icon-size) / -2);
-  background-size: var(--big-icon-size) var(--big-icon-size);
+  background-size: var(--big-icon-size);
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-position: center;
@@ -107,10 +108,15 @@
   line-height: 1.1;
 }
 .catastrophe-popup .leaflet-popup-content-wrapper {
-  overflow: hidden;
+  background-color: transparent;
+}
+
+.popup-content-container {
+  border-radius: var(--popup-border-radius);
 }
 
 .catastrophe-popup .leaflet-popup-content {
   background-color: var(--clr-beige);
   color: var(--clr-gris-fonce);
+  border-radius: var(--popup-border-radius);
 }

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -5,7 +5,7 @@
                 <div id="modal-header">
                     <img class="logo" src="/Logo_terreOS_About.png" alt="terreOS">
                     <a id="close-button" @click="closeModal">
-                        <img src="/Button/Close.png" alt="✕">
+                        <span aria-hidden="true">&#x00d7;</span>
                     </a>
                 </div>
                 <div id="modal-content">
@@ -117,13 +117,31 @@ img {
 }
 
 #close-button {
-    display: block;
-    cursor: pointer;
     position: absolute;
-    top: 0;
-    right: 0;
-    height: 100%;
-    padding: 4px;
+    top: calc((var(--sz-900) - var(--sz-700)) / 2);
+    right: calc((var(--sz-900) - var(--sz-700)) / 2);
+    cursor: pointer;
+    width: var(--sz-700);
+    height: var(--sz-700);
+    border-radius: 50%;
+    background-color: var(--clr-gris-pale);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#close-button span {
+  display: block;
+  color: var( --clr-blanc);
+  font-size: var(--sz-600);
+  line-height: var(--sz-600);
+  width: var(--sz-600);
+  height: var(--sz-600);
+  text-align: center;
+}
+
+#close-button:hover span {  
+  color: var(--clr-gris-moyen);
 }
 
 #modal-header {

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -192,14 +192,15 @@ img {
 }
 
 #detailed-data {
-    font-size: var(--sz-200);
+    font-size: var(--sz-400);
     color: var(--clr-gris-moyen);
     width: 100%;
 }
 
 #detailed-data ul {
     padding: 0;
-    font-size: var(--sz-100);
+    font-size: var(--sz-300);
+    line-height: var(--sz-400);
     padding: var(--sz-600);
     padding-top: 0;
 }

--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -40,12 +40,16 @@ export default defineComponent({
     height: var(--sz-900);
     padding-left: var(--sz-50);
     padding-right: var(--sz-50);
+    border-radius: var(--popup-border-radius);
     display: flex;
     align-items: center;
 }
 
 time {
     white-space: nowrap;
+    height: var(--sz-700);
+    display: flex;
+    align-items: center;
 }
 
 #catastrophe-list {
@@ -65,9 +69,13 @@ time {
 }
 
 .icon {
-    min-width: var(--sz-600);
-    min-height: var(--sz-600);
-    background-size: var(--sz-600) var(--sz-600);
+    width: var(--sz-700);
+    height: var(--sz-700);
+    background-size: var(--sz-700);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: center;
+    margin-bottom: 4px;
 }
 
 .details {

--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -40,7 +40,7 @@ export default defineComponent({
     height: var(--sz-900);
     padding-left: var(--sz-50);
     padding-right: var(--sz-50);
-    border-radius: var(--popup-border-radius);
+    border-radius: var(--border-radius);
     display: flex;
     align-items: center;
 }

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -49,20 +49,29 @@ export default defineComponent({
 #header {
     font-size: var(--sz-400);
     background-color: var(--clr-blanc);
+    border-radius: var(--popup-border-radius);
     height: var(--sz-900);
     padding-right: var(--sz-50);
     display: flex;
     align-items: center;
-    gap: 4px;
+}
+
+.title {
+    margin-left: calc(var(--sz-30) / -2);
 }
 
 .icon {
+    position: relative;
     display: block;
     object-fit: contain;
-    min-width: var(--sz-800);
-    min-height: var(--sz-800);
-    background-size: var(--sz-800) var(--sz-800);
-    margin: 4px;
+    width: calc(var(--sz-900) + var(--sz-50));
+    height: calc(var(--sz-900) + var(--sz-50));
+    background-size: calc(var(--sz-900) + var(--sz-50));
+    border-radius: 50%;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: center;
+    left: calc(var(--sz-30) * -1);
 }
 
 #body-content {

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -49,7 +49,7 @@ export default defineComponent({
 #header {
     font-size: var(--sz-400);
     background-color: var(--clr-blanc);
-    border-radius: var(--popup-border-radius);
+    border-radius: var(--border-radius);
     height: var(--sz-900);
     padding-right: var(--sz-50);
     display: flex;

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -77,6 +77,7 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
     });
     popup.setContent(() => {
         const div = document.createElement('div');
+        div.classList.add('popup-content-container');
         const details = modelFactory();
         details.appContext = appContext;
         render(details, div);

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -71,7 +71,7 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
         opacity: 1
     });
     const popup = L.popup({
-        className: 'catastrophe-popup',
+        className: `catastrophe-popup` ,
         closeOnClick: false,
     });
     popup.setContent(() => {

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -72,7 +72,6 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
     });
     const popup = L.popup({
         className: 'catastrophe-popup',
-        closeButton: false,
         closeOnClick: false,
     });
     popup.setContent(() => {


### PR DESCRIPTION
- L'icône dans le coin du popup d'un fait saillant "déborde" maintenant de ses bordures.
- Ajout d'un bouton de fermeture sur tous les popups (et modification du bouton de fermeture de la fenêtre d'à propos pour avoir le même look)
- Les popups ont maintenant la même courbure de coin que le reste de l'application (avant, hard codé à 12px)
- La "queue" d'un popup a maintenant la même couleur que tout le popup.
- Les sources de la fenêtre d'à propos ne seront plus trop petit à des petites résolutions

![image](https://user-images.githubusercontent.com/4632802/191139596-46561c58-b994-45dd-b914-01b64063604e.png)
