### PR TITLE
Workaround pour un bug dans Leaflet.

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -124,6 +124,8 @@
   align-items: center;
   margin-right: calc((var(--sz-900) - var(--sz-700)) / 2);
   margin-top: calc((var(--sz-900) - var(--sz-700)) / 2);
+  z-index: 1000;
+  cursor: pointer;
 }
 
 .leaflet-container a.leaflet-popup-close-button span {

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -77,6 +77,11 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
     });
     popup.setContent(() => {
         const div = document.createElement('div');
+
+        // Workaround for https://github.com/Leaflet/Leaflet/issues/8159
+        // Official Leaflet fix to be released in 1.8.1
+        // Once the fix is in, we can put closeButton above back to true
+        // and remove the following block of code
         const closeButton = document.createElement('a');
         closeButton.classList.add('leaflet-popup-close-button');
         closeButton.href = '#';

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -53,7 +53,7 @@ function generateIcons(baseClassName: string, generateAsInnerDiv: boolean): Map<
         if (generateAsInnerDiv) {
             options.className = '';
             options.html = `<div class="${baseClassName} catastrophe-icon-${value.toLowerCase()}"></div>`;
-        } else {            
+        } else {
             options.className = `${baseClassName} catastrophe-icon-${value.toLowerCase()}`;
         }
         const icon = L.divIcon(options);
@@ -71,11 +71,24 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
         opacity: 1
     });
     const popup = L.popup({
-        className: `catastrophe-popup` ,
+        className: `catastrophe-popup`,
         closeOnClick: false,
+        closeButton: false
     });
     popup.setContent(() => {
         const div = document.createElement('div');
+        const closeButton = document.createElement('a');
+        closeButton.classList.add('leaflet-popup-close-button');
+        closeButton.href = '#';
+        closeButton.setAttribute('role', 'button');
+        closeButton.ariaLabel = 'Close button';
+        closeButton.innerHTML = '<span aria-hidden="true">&#x00d7;</span>';
+        closeButton.addEventListener('click', ev => {
+            marker.closePopup();
+            ev.preventDefault();
+        });
+        div.appendChild(closeButton);
+
         div.classList.add('popup-content-container');
         const details = modelFactory();
         details.appContext = appContext;


### PR DESCRIPTION
Leaflet 1.8.0 a introduit un bug qui fait que cliquer sur un bouton de fermeture de popup ajoute un #close dans l'URL. Ça fait pas mal laid, pis on a pas le temps d'attendre la 1.8.1 qui règle ça, donc la solution optimale est de simplement recréer nous même le bouton de fermeture.