### PR TITLE
Alignements verticaux

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -235,10 +235,6 @@ Sentry.init({
     max-height: 100%;
     max-width: 600px;
     padding-right: var(--sz-50);
-    display: flex;
-    flex-direction: column;
-    justify-content: start;
-    gap: var(--size-map-controls-gap);
 }
 
 .call-to-action {
@@ -263,6 +259,8 @@ Sentry.init({
     --vs-border-radius: var(--border-radius);
     --vs-border-color: var(--color-border);
     --vs-dropdown-max-height: 750%;
+    height: var(--sz-900);
+    margin-bottom: var(--size-map-controls-gap);
 }
 
 .timeline {

--- a/src/components/PillBadge.vue
+++ b/src/components/PillBadge.vue
@@ -16,13 +16,20 @@ export default defineComponent({
 
 <style scoped>
 div {
-    display: inline;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     border-radius: var(--border-radius);
     font-size: var(--sz-400);
     color: var(--clr-blanc);
     background-color: var(--color-accent);
-    padding: 1px var(--sz-30) 2px var(--sz-30);
-    width: min-content;
+    width: 5ch;
     text-align: center;
+    padding: 2px 0;
+}
+span {
+    height: 100%;
+    display: block;
+    font-size: var(--sz-500);
 }
 </style>

--- a/src/components/RegionSearch.vue
+++ b/src/components/RegionSearch.vue
@@ -48,4 +48,7 @@ export default defineComponent({
     overflow: hidden;
     white-space: nowrap;
 }
+.v-select .vs__dropdown-toggle {
+    height: 100%;
+}
 </style>

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -271,16 +271,20 @@ export default defineComponent({
     position: absolute;
     left: 50%;
     transform: translate(-50%, 50%);
-    width: max-content;
-    padding: 1px 4px;
+    padding: 2px 4px;
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    line-height: 1.3;
     gap: var(--sz-50);
     color: var(--clr-blanc);
     border-radius: var(--border-radius);
+    line-height: 100%;
+}
+
+.pill span {
+    display: block;
+    height: 100%;
+    white-space: nowrap;
 }
 
 .current-value {
@@ -298,9 +302,9 @@ export default defineComponent({
 }
 
 .reference-value {
-    min-width: 55px;
     background-color: var(--clr-thermometer-mercury);
     font-size: var(--sz-200);
+    padding: 2px 6px;
 }
 
 .risky-value {


### PR DESCRIPTION
- Nettoyage du CSS autour des pilules dans le filtre de catastrophe, pour un alignment vertical plus fiable.
- Alignment vertical de l'année de référence sur le thermomètre
- La boîte de recherche par région a maintenant la même hauteur que le filtre de catastrophe.