### PR TITLE
Corrections de backgrounds

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -15,7 +15,7 @@
   height: var(--icon-size);
   margin-top: calc(var(--icon-size) / -2);
   margin-left: calc(var(--icon-size) / -2);
-  background-size: var(--icon-size);
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
 }
@@ -25,7 +25,7 @@
   height: var(--big-icon-size);
   margin-top: calc(var(--big-icon-size) / -2);
   margin-left: calc(var(--big-icon-size) / -2);
-  background-size: var(--big-icon-size);
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
   

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -17,7 +17,6 @@
   margin-left: calc(var(--icon-size) / -2);
   background-size: var(--icon-size);
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-position: center;
 }
 
@@ -28,7 +27,6 @@
   margin-left: calc(var(--big-icon-size) / -2);
   background-size: var(--big-icon-size);
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-position: center;
   
   border: 2px solid white;

--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -71,7 +71,7 @@ time {
 .icon {
     width: var(--sz-700);
     height: var(--sz-700);
-    background-size: var(--sz-700);
+    background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
     margin-bottom: 4px;

--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -73,7 +73,6 @@ time {
     height: var(--sz-700);
     background-size: var(--sz-700);
     background-repeat: no-repeat;
-    background-attachment: fixed;
     background-position: center;
     margin-bottom: 4px;
 }

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -66,7 +66,7 @@ export default defineComponent({
     object-fit: contain;
     width: calc(var(--sz-900) + var(--sz-50));
     height: calc(var(--sz-900) + var(--sz-50));
-    background-size: calc(var(--sz-900) + var(--sz-50));
+    background-size: cover;
     border-radius: 50%;
     background-repeat: no-repeat;
     background-position: center;

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -69,7 +69,6 @@ export default defineComponent({
     background-size: calc(var(--sz-900) + var(--sz-50));
     border-radius: 50%;
     background-repeat: no-repeat;
-    background-attachment: fixed;
     background-position: center;
     left: calc(var(--sz-30) * -1);
 }


### PR DESCRIPTION
On a pas besoin de background-attachment: fixed, et anyway ça chie sur Safari.
Également, utilisation de background-size: cover plutôt que de mettre une taille à la main.