### PR TITLE
Timeline fix 2050/2100 issue: reduce modeled years, add 'padding'

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -170,9 +170,8 @@ export default defineComponent({
         const baseOptions = Map(fromJS({
             onClick: (e: ChartEvent, tooltipItems: ActiveElement[], chart: ChartJS) => {
                 const canvasPosition = getRelativePosition(e, chart)
-                const yearId = chart.scales.x.getValueForPixel(canvasPosition.x);
-                // TODO: fix this
-                // emit('yearSelected', TIMELINE_YEARS[yearId ?? 0]);
+                const value = chart.scales.x.getValueForPixel(canvasPosition.x) ?? 0;
+                emit('yearSelected', markValueToYear(value));
             },
             plugins: {
                 legend: {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -15,7 +15,10 @@
                     :marks="marks" :adsorb="true" :drag-on-click="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
-                        <div :class="['vue-slider-mark-label', 'custom-label']">{{value}}</div>
+                        <div :class="['vue-slider-mark-label', 'custom-label']"
+                            :data-year="value">
+                            {{value}}
+                        </div>
                     </template>
                     <template v-slot:step="{ active }">
                         <div :class="['vue-slider-mark-step', {'vue-slider-mark-step-active': active}]"></div>
@@ -238,6 +241,7 @@ export default defineComponent({
         },
         generateMarks(): Marks {
             const marks = {};
+            // Only create mark elements for _some_ of the continuous years.
             CONTINUOUS_YEARS.filter(y => y % 5 == 0).forEach(year => {
                 marks[year] = this.generateMark(year);
             });
@@ -300,6 +304,13 @@ export default defineComponent({
 .vue-slider .vue-slider-mark .vue-slider-mark-label,
 .vue-slider .vue-slider-mark .vue-slider-mark-step {
     display: block;
+}
+
+.vue-slider .vue-slider-mark .vue-slider-mark-label:is(
+    [data-year^='2030'],
+    [data-year^='2050'],
+) {
+    display: none;
 }
 
 .vue-slider .vue-slider-mark .vue-slider-mark-label {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -46,11 +46,11 @@
 </template>
 
 <script lang="ts">
-import VueSlider from 'vue-slider-component'
+import VueSlider, { Marks, MarkOption } from 'vue-slider-component'
 import { Map, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
-import { MIN_CONTINUOUS_YEAR, TIMELINE_YEARS } from '@/models/constants';
+import { CONTINUOUS_YEARS, MODELED_YEARS, TIMELINE_YEARS } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { useStatisticStore } from '@/stores/statistics';
 import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from '@/models/catastrophes';
@@ -175,16 +175,8 @@ export default defineComponent({
         };
     },
     data() {
-        // TODO: hide some of the marks (+labels) via CSS
-        const marks = TIMELINE_YEARS.reduce((obj, year) => {
-            obj[year] = {
-                label: year.toString(),
-                pos: this.getRenderedYearRatio(year) * 100,
-            };
-            return obj;
-        }, {});
         return {
-            marks,
+            marks: this.generateMarks(),
             years: TIMELINE_YEARS,
         };
     },
@@ -237,6 +229,23 @@ export default defineComponent({
             // before and after modeled years.
             const index = TIMELINE_YEARS.indexOf(year);
             return index / (TIMELINE_YEARS.length - 1);
+        },
+        generateMark(year: number): MarkOption {
+            return {
+                label: year.toString(),
+                pos: this.getRenderedYearRatio(year) * 100,
+            };
+        },
+        generateMarks(): Marks {
+            const marks = {};
+            CONTINUOUS_YEARS.filter(y => y % 5 == 0).forEach(year => {
+                marks[year] = this.generateMark(year);
+            });
+            // TODO: hide some of the labels via CSS
+            MODELED_YEARS.forEach(year => {
+                marks[year] = this.generateMark(year);
+            });
+            return marks
         },
     },
 });

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -294,7 +294,7 @@ export default defineComponent({
             return TIMELINE_YEARS.reduce((marks, year) => {
                 marks[yearToMarkValue(year)] = year.toString();
                 return marks;
-            }, {});
+            }, {} as Marks);
         },
     },
 });

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -50,7 +50,7 @@ import VueSlider from 'vue-slider-component'
 import { Map, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
-import { TIMELINE_YEARS, BEGIN_MODELED_YEAR } from '@/models/constants';
+import { MIN_CONTINUOUS_YEAR, TIMELINE_YEARS } from '@/models/constants';
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { useStatisticStore } from '@/stores/statistics';
 import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from '@/models/catastrophes';
@@ -175,14 +175,17 @@ export default defineComponent({
         };
     },
     data() {
-        const ratio = TIMELINE_YEARS.filter(x => x <= BEGIN_MODELED_YEAR).length / TIMELINE_YEARS.length;
+        // TODO: hide some of the marks (+labels) via CSS
+        const marks = TIMELINE_YEARS.reduce((obj, year) => {
+            obj[year] = {
+                label: year.toString(),
+                pos: this.getRenderedYearRatio(year) * 100,
+            };
+            return obj;
+        }, {});
         return {
-            marks: TIMELINE_YEARS,
+            marks,
             years: TIMELINE_YEARS,
-            modeledYearsStyle: [
-                'left:' + (ratio * 100) + '%',
-                'width:' + ((1 - ratio) * 100) + '%'
-            ]
         };
     },
     computed: {
@@ -224,7 +227,18 @@ export default defineComponent({
             };
             return data;
         }
-    }
+    },
+    methods: { 
+        getRenderedYearRatio(year: number): number {
+            // For a given year, give the ratio out of the TIMELINE_YEARS where
+            // it should fit (e.g. for 1990-2100, 1990 = 0.0, 2100 = 1.0).
+
+            // TODO: take into account "interpolated" years, added as padding
+            // before and after modeled years.
+            const index = TIMELINE_YEARS.indexOf(year);
+            return index / (TIMELINE_YEARS.length - 1);
+        },
+    },
 });
 </script>
 
@@ -276,7 +290,7 @@ export default defineComponent({
 
 .vue-slider .vue-slider-mark .vue-slider-mark-label,
 .vue-slider .vue-slider-mark .vue-slider-mark-step {
-    display: none;
+    display: block;
 }
 
 .vue-slider .vue-slider-mark .vue-slider-mark-label {
@@ -299,29 +313,6 @@ export default defineComponent({
 .timeline-container {
     /* Undo the timeline component padding to push to the left side */
     margin-left: calc(0px - var(--timeline-horizontal-padding));
-}
-
-@media screen and (min-width: 768px) {
-
-    .vue-slider .vue-slider-mark:nth-child(5n+1) .vue-slider-mark-label,
-    .vue-slider .vue-slider-mark:nth-child(5n+1) .vue-slider-mark-step,
-    .vue-slider .vue-slider-mark:nth-last-child(2) .vue-slider-mark-label,
-    .vue-slider .vue-slider-mark:nth-last-child(2) .vue-slider-mark-step,
-    .vue-slider .vue-slider-mark:last-child .vue-slider-mark-label,
-    .vue-slider .vue-slider-mark:last-child .vue-slider-mark-step {
-        display: block;
-    }
-}
-
-@media screen and (max-width: 768px) {
-
-    .vue-slider .vue-slider-mark:nth-child(10n+1) .vue-slider-mark-label,
-    .vue-slider .vue-slider-mark:nth-child(10n+1) .vue-slider-mark-step,
-    .vue-slider .vue-slider-mark:nth-last-child(2) .vue-slider-mark-label,
-    .vue-slider .vue-slider-mark:nth-last-child(2) .vue-slider-mark-step,
-    .vue-slider .vue-slider-mark:last-child .vue-slider-mark-step {
-        display: block;
-    }
 }
 
 .graph-unit {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -6,7 +6,7 @@ export const MAX_CONTINUOUS_YEAR = 2022;
 export const CONTINUOUS_YEARS = Range(MIN_CONTINUOUS_YEAR, MAX_CONTINUOUS_YEAR + 1).toArray();
 
 // NOTE: Past 2035, we only have data for 2050 and 2100.
-export const MODELED_YEARS = [2025, 2030, 2035, 2050, 2100];
+export const MODELED_YEARS = [2030, 2050, 2100];
 
 export const TIMELINE_YEARS = CONTINUOUS_YEARS.concat(MODELED_YEARS).sort();
 export const CURRENT_YEAR = new Date().getFullYear();

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -6,6 +6,7 @@ export const MAX_CONTINUOUS_YEAR = 2022;
 export const CONTINUOUS_YEARS = Range(MIN_CONTINUOUS_YEAR, MAX_CONTINUOUS_YEAR + 1).toArray();
 
 // NOTE: Past 2035, we only have data for 2050 and 2100.
+// NOTE: timeline CSS has assumptions that all modeled years end in 0.
 export const MODELED_YEARS = [2030, 2050, 2100];
 
 export const TIMELINE_YEARS = CONTINUOUS_YEARS.concat(MODELED_YEARS).sort();

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,8 +1,12 @@
+import { Range } from 'immutable';
+
 export const REFERENCE_YEAR = 1990;  // For delta temperatures
 export const MIN_CONTINUOUS_YEAR = REFERENCE_YEAR;
-export const MAX_CONTINUOUS_YEAR = 2035;
-export const FUTURE_SCENARIO_YEAR1 = 2050;
-export const FUTURE_SCENARIO_YEAR2 = 2100;
-export const TIMELINE_YEARS = [...Array(((MAX_CONTINUOUS_YEAR - MIN_CONTINUOUS_YEAR)) + 1).keys()].map(x => MIN_CONTINUOUS_YEAR + x ).concat(FUTURE_SCENARIO_YEAR1, FUTURE_SCENARIO_YEAR2).sort();
+export const MAX_CONTINUOUS_YEAR = 2022;
+export const CONTINUOUS_YEARS = Range(MIN_CONTINUOUS_YEAR, MAX_CONTINUOUS_YEAR + 1).toArray();
+
+// NOTE: Past 2035, we only have data for 2050 and 2100.
+export const MODELED_YEARS = [2025, 2030, 2035, 2050, 2100];
+
+export const TIMELINE_YEARS = CONTINUOUS_YEARS.concat(MODELED_YEARS).sort();
 export const CURRENT_YEAR = new Date().getFullYear();
-export const BEGIN_MODELED_YEAR = 2014;

--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -1,0 +1,84 @@
+import { Range } from 'immutable';
+
+// Helper to manage interpolated 'padding years' around modeled years, to
+// produce some visual padding.
+//
+// E.g. instead of having:
+// ... 2020 2021 2022 2030 2050 2100
+// add some conceptual padding years 'P' before and between modeled years (in
+// this example, use 3 'padding' years):
+// ... 2020 2021 2022 P P P 2030 P P P 2050 P P P 2100
+//
+// For graphs, we linearly interpolate values on padding points between the real
+// values.
+//
+// To use this class, make visual representations use the 'indices' produced by
+// this class for positioning, while using helper classes to convert to/from
+// years. For data mapped to years, use 'interpolate' to get interpolated data
+// for each index.
+
+export interface InterpolatedData {
+    indices: number[];
+    data: number[];
+}
+
+export class InterpolatedYears {
+    continuous: number[];
+    modeled: number[];
+    padding: number;
+
+    constructor(continuousYears: number[], modeledYears: number[],
+        paddingYears: number) {
+        this.continuous = continuousYears;
+        this.modeled = modeledYears;
+        this.padding = paddingYears;
+
+        // How many indices do we have in total, with padding years?
+        this.totalYearsPadded = (
+            this.continuous.length + (this.padding + 1) * this.modeled.length);
+    }
+
+    indexToYear(index: number): number {
+        if (index < this.continuous.length) {
+            return this.continuous[index];
+        }
+        const start = this.continuous.length + this.padding;
+        // TODO: this isn't right, see PR comments
+        index -= start;
+        const modelIndex = Math.floor(index / (this.padding + 1));
+        return this.modeled[modelIndex];
+    }
+
+    yearToIndex(year: number): number {
+        if (year <= this.continuous.at(-1)) {
+            return year - this.continuous[0];
+        }
+        const modeledIndex = this.modeled.indexOf(year);
+        const start = this.continuous.length + this.padding;
+        return start + modeledIndex * (this.padding + 1);
+    }
+
+    interpolate(data: number[]): InterpolatedData {
+        // Takes in datapoints that mapped to continuous + modeled years and
+        // adds interpolated values where 'padding' years would lie.
+        const interpolated: InterpolatedData = {
+            indices: Range(0, this.continuous.length).toArray(),
+            data: data.slice(0, this.continuous.length),
+        };
+        let index = this.continuous.length;
+        let previous = data[index-1];
+        for (const current of data.slice(index)) {
+            Range(0, this.padding).forEach(i => {
+                const ratio = (i + 1) / (this.padding + 1);
+                const lerp = (1 - ratio) * previous + ratio * current;
+                interpolated.indices.push(index);
+                interpolated.data.push(lerp);
+                ++index;
+            });
+            interpolated.indices.push(index);
+            interpolated.data.push(current);
+            previous = current;
+        }
+        return interpolated;
+    }
+};

--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -27,13 +27,15 @@ export class InterpolatedYears {
     modeled: number[];
     padding: number;
 
+    // How many indices do we have in total, with padding years?
+    totalYearsPadded: number;
+
     constructor(continuousYears: number[], modeledYears: number[],
         paddingYears: number) {
         this.continuous = continuousYears;
         this.modeled = modeledYears;
         this.padding = paddingYears;
 
-        // How many indices do we have in total, with padding years?
         this.totalYearsPadded = (
             this.continuous.length + (this.padding + 1) * this.modeled.length);
     }
@@ -50,7 +52,7 @@ export class InterpolatedYears {
     }
 
     yearToIndex(year: number): number {
-        if (year <= this.continuous.at(-1)) {
+        if (year <= this.continuous[this.continuous.length - 1]) {
             return year - this.continuous[0];
         }
         const modeledIndex = this.modeled.indexOf(year);

--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -45,7 +45,6 @@ export class InterpolatedYears {
             return this.continuous[index];
         }
         const start = this.continuous.length + this.padding;
-        // TODO: this isn't right, see PR comments
         index -= start;
         const modelIndex = Math.floor(index / (this.padding + 1));
         return this.modeled[modelIndex];


### PR DESCRIPTION
The >2022 timeline took too much space and at the same time was too crowded (e.g. 2050/2100 overlap). This change removes years post-2022 from the continuous timeline and instead only keeps a few deliberate modeling years, for now `[2030, 2050, 2100]`.

The issue is then that modeling years look too clumped together, because they're treated like they're 1 year apart visually. This change adds the concept of "interpolated padding years", where e.g. currently 3 "visual padding" years are assumed to sit before and between modeled years to give some spacing. To make that happen:
- `vue-slider` now tracks indices in this conceptual 'padded years' list, and we map between years and mark values with helper functions (we use `include` to force the slider to only allow the explicit marks);
- chart data includes linearly interpolated points between modeled years to map to 'padding years'.

Other changes:
- Replace the label & step show/hide CSS selection with a CSS selector based on a `data-year` attribute that we add;
- Show all 3 modeled years on non-phone screens, since they fit with the "3 years" padding;
- Add right padding on the timeline to make space for the last `2100` label.

On mobile:
![image](https://user-images.githubusercontent.com/1843555/191185574-840e4ace-b8d5-4351-b691-d0ebac60888c.png)

On desktop:
![image](https://user-images.githubusercontent.com/1843555/191185642-92d33f2a-8d1d-4cc4-bcf2-389fd3f6d117.png)
