### PR TITLE
Break up past from future values in timeline + change gradient

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -228,11 +228,15 @@ export default defineComponent({
         catastropheData() {
             const { indices, data } = VISUAL_YEARS.interpolate(
                 TIMELINE_YEARS.map(year => this.catastropheStore.countCatastrophes(year, this.district, this.catastropheFilter ?? FILTER_ALL_CATASTROPHES)));
+            // Future years have unknown values, set null to replace
+            // interpolated values.
+            const lastPastIndex = VISUAL_YEARS.yearToIndex(MAX_CONTINUOUS_YEAR);
+            const pastData = data.slice(0, lastPastIndex + 1).concat(Repeat(null, data.length - lastPastIndex - 1).toArray());
             return {
                 labels: indices,
                 datasets: [
                     {
-                        data,
+                        data: pastData,
                         borderWidth: 0,
                         backgroundColor: '#f0ad00'
                     }

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -207,12 +207,16 @@ export default defineComponent({
                 pointRadius: 0,
                 backgroundColor: (ctx: ScriptableContext<'line'>) => {
                     const canvas = ctx.chart.ctx;
-                    const gradient = canvas.createLinearGradient(0, 0, 0, 90);
+                    const chartArea = ctx.chart.chartArea;
+                    if (!chartArea) return;  // not set on init
+                    const yAxis = ctx.chart.scales.y;
+                    const zeroRatio = -yAxis.min / (yAxis.max - yAxis.min);
+                    const gradient = canvas.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
 
-                    //TODO: mettre le bon gradiant et les bonnes couleurs
-                    gradient.addColorStop(0, 'red');
-                    gradient.addColorStop(0.5, 'orange');
-                    gradient.addColorStop(0.8, 'lightblue');
+                    gradient.addColorStop(0.9, '#FF3B3B');
+                    gradient.addColorStop(zeroRatio + 0.03, '#F0AD00');
+                    gradient.addColorStop(zeroRatio, '#F4F3E7');
+                    gradient.addColorStop(0, '#005AAD');
 
                     return gradient;
                 },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -203,8 +203,8 @@ export default defineComponent({
             // Split up in two charts to get a break for future values
             const pastData = (data.slice(0, lastPastIndex + 1) as ChartElem[]).concat(
                 Repeat(null as ChartElem, data.length - lastPastIndex - 1).toArray());
-            const futureData = Repeat(null as ChartElem, lastPastIndex + 1).toArray().concat(
-                data.slice(lastPastIndex + 1));
+            const futureData = Repeat(null as ChartElem, lastPastIndex).toArray().concat(
+                data.slice(lastPastIndex));
             const datasetBase = {
                 fill: true,
                 spanGaps: false,

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -80,7 +80,8 @@ const INTERPOLATED_PADDING_YEARS = 3;
 const VISUAL_YEARS = new InterpolatedYears(CONTINUOUS_YEARS, MODELED_YEARS,
                                            INTERPOLATED_PADDING_YEARS);
 
-type GradientGenerator = (ctx: ScriptableContext) => CanvasGradient | undefined;
+type GradientGenerator = (ctx: ScriptableContext<'line'>) => CanvasGradient | undefined;
+type ChartElem = number | null;
 
 export default defineComponent({
     components: { VueSlider, Line, TimelineArrow, Bar },
@@ -200,8 +201,10 @@ export default defineComponent({
                 TIMELINE_YEARS.map(year => this.statisticStore.findStatistics(year, this.district).temp_delta ?? 0));
             const lastPastIndex = VISUAL_YEARS.yearToIndex(MAX_CONTINUOUS_YEAR);
             // Split up in two charts to get a break for future values
-            const pastData = data.slice(0, lastPastIndex + 1).concat(Repeat(null, data.length - lastPastIndex - 1).toArray());
-            const futureData = Repeat(null, lastPastIndex + 1).toArray().concat(data.slice(lastPastIndex + 1));
+            const pastData = (data.slice(0, lastPastIndex + 1) as ChartElem[]).concat(
+                Repeat(null as ChartElem, data.length - lastPastIndex - 1).toArray());
+            const futureData = Repeat(null as ChartElem, lastPastIndex + 1).toArray().concat(
+                data.slice(lastPastIndex + 1));
             const datasetBase = {
                 fill: true,
                 spanGaps: false,
@@ -234,7 +237,8 @@ export default defineComponent({
             // Future years have unknown values, set null to replace
             // interpolated values.
             const lastPastIndex = VISUAL_YEARS.yearToIndex(MAX_CONTINUOUS_YEAR);
-            const pastData = data.slice(0, lastPastIndex + 1).concat(Repeat(null, data.length - lastPastIndex - 1).toArray());
+            const pastData = (data.slice(0, lastPastIndex + 1) as ChartElem[]).concat(
+                Repeat(null, data.length - lastPastIndex - 1).toArray());
             return {
                 labels: indices,
                 datasets: [


### PR DESCRIPTION
- Show a visual break between today & future values by displaying 2 charts: past and future values;
- Change gradient to match a bit closer to the design, automatically places gradient color break point dynamically based on where `0` is on the canvas;
- Show transparent gradient for future values;
- Also fix catastrophes to only show past values -- otherwise we see tiny interpolated values shortly after 2022.

On desktop the gap is pretty large, but not sure how else to introduce the line break through ChartJS (and doing it via hacky HTML/CSS sounds not ideal/tricky -- it would hide e.g. the chart horizontal lines)... I don't think it's _too_ weird as-is, but it's not ideal.

Mobile:
![image](https://user-images.githubusercontent.com/1843555/191421106-467f120c-8dd0-42d2-8853-987d3f9d5a0d.png)

Desktop:
![image](https://user-images.githubusercontent.com/1843555/191421154-4337f280-bcee-4aa0-866a-725f2310f778.png)
