### PR TITLE
Fix bug when clicking on first padding years

### DIFF
--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -85,6 +85,6 @@ export class InterpolatedYears {
     }
 };
 
-function clamp(value, min, max) {
+function clamp(value: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, value));
 }

--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -44,11 +44,12 @@ export class InterpolatedYears {
         if (index < this.continuous.length) {
             return this.continuous[index];
         }
-        const start = this.continuous.length + this.padding;
-        index -= start;
-        const modelIndex = Math.floor(index / (this.padding + 1));
-        return this.modeled[modelIndex];
-    }
+        const lastContinuousIndex = this.continuous.length - 1;
+        index -= lastContinuousIndex;
+        const numModeled = Math.round(index / (this.padding + 1));
+        const modeledIndex = clamp(numModeled - 1, 0, this.modeled.length - 1);
+        return this.modeled[modeledIndex];
+    };
 
     yearToIndex(year: number): number {
         if (year <= this.continuous[this.continuous.length - 1]) {
@@ -83,3 +84,7 @@ export class InterpolatedYears {
         return interpolated;
     }
 };
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}


### PR DESCRIPTION
The code had assumptions that padding years are never passed to indexToYear (since they shouldn't with current vue-slider mark setup), but this breaks apart when we call this onClick on the chart, where that can now happen.

Changed the logic flow a bit to make it easier to work with, changed to Math.round to snap to closest non-padding year, and added clamp for cases where the Math.round would snap to invalid index (on the padding before the first modeled year).