### PR TITLE
Change thermo to relative temp + costmetic

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -49,6 +49,7 @@
   --timeline-horizontal-padding: var(--sz-200);
   --modal-width: 75%;
   --popup-width: 216px;
+  --thermo-current-value-width: 9ch;
 
   /* Font weight variants */
   --fw-regular: 500;
@@ -91,6 +92,7 @@
     --sz-900: 38px;
 
     --popup-width: 332px;
+    --thermo-current-value-width: 8ch;
   }
 }
 

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -33,7 +33,7 @@
 
         <div class="current-value pill tracked-current track-bottom">
             <img :src="emojiPath" data-tutorial-step="temperature">
-            <span>{{$n(currentValueDisplayed, 'temperature')}}</span>
+            <span>{{$n(currentValueDisplayed, 'temperature_delta')}}</span>
         </div>
     </div>
 </template>
@@ -79,7 +79,7 @@ export default defineComponent({
             return this.statistics.temp_delta ?? 0;
         },
         currentValueDisplayed(): number {
-            return this.statistics.avg_temp ?? 0;
+            return this.statistics.temp_delta ?? 0;
         },
         referenceValue(): number {
             return this.referenceStatistics.temp_delta ?? 0;
@@ -286,7 +286,7 @@ export default defineComponent({
 }
 
 .current-value {
-    min-width: calc(var(--sz-900) * 2);
+    width: var(--thermo-current-value-width);
     border: 2px solid var(--clr-blanc);
     background-color: var(--color-accent);
     font-size: var(--sz-400);
@@ -300,6 +300,7 @@ export default defineComponent({
 }
 
 .reference-value {
+    width: 11ch;
     background-color: var(--clr-thermometer-mercury);
     font-size: var(--sz-200);
     padding: 2px 6px;
@@ -307,7 +308,7 @@ export default defineComponent({
 
 .risky-value {
     font-size: var(--sz-300);
-    min-width: 80px;
+    width: 11ch;
 }
 
 .risky-value > span {


### PR DESCRIPTION
- Show temp_delta, with the right formatting;
- Change current-value width to be based on chars, with a breakpoint. It was too small before in some cases (e.g. "+10.0 C");
- Change the reference value similarly;
- Fix the "+1.5" line to be dynamic, it was broken on desktop.

![image](https://user-images.githubusercontent.com/1843555/191430160-712de930-b16a-4c48-a5d9-92249bd0ba25.png)

![image](https://user-images.githubusercontent.com/1843555/191430231-0faf33ea-b5d3-4f15-9170-72759f336718.png)
