### PR TITLE
Tutorial welcome step

### DIFF
--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -60,6 +60,15 @@ export default defineComponent({
                 },
             },
             steps: [
+                // Note: important to have a first step target that does not
+                // depend on loaded data for its placement (or e.g. no target).
+                {
+                    // TODO(emond): Switch to no target, but then need to fix
+                    // styling...
+                    target: '[data-tutorial-step="year-selector"]',
+                    content: this.$t('tutorial_welcome_html'),
+                    params: baseParams,
+                },
                 {
                     target: '[data-tutorial-step="temperature"]',
                     content: this.$t('tutorial_temperature_html'),

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -1,7 +1,9 @@
 <template>
     <v-tour name="tutorial" :steps="steps" :options="options" :callbacks="callbacks" v-slot="tour">
         <transition name="fade">
-            <v-step v-if="tour.steps[tour.currentStep]" :step="tour.steps[tour.currentStep]" :key="tour.currentStep"
+            <v-step
+                id="v-step"
+                v-if="tour.steps[tour.currentStep]" :step="tour.steps[tour.currentStep]" :key="tour.currentStep"
                 :previous-step="tour.previousStep" :next-step="tour.nextStep" :stop="tour.stop" :skip="tour.skip"
                 :is-first="tour.isFirst" :is-last="tour.isLast" :labels="tour.labels"
                 :enabled-buttons="tour.enabledButtons" :debug="tour.debug">
@@ -63,9 +65,6 @@ export default defineComponent({
                 // Note: important to have a first step target that does not
                 // depend on loaded data for its placement (or e.g. no target).
                 {
-                    // TODO(emond): Switch to no target, but then need to fix
-                    // styling...
-                    target: '[data-tutorial-step="year-selector"]',
                     content: this.$t('tutorial_welcome_html'),
                     params: baseParams,
                 },
@@ -124,17 +123,6 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.v-tour :deep(.v-step) {
-    --header-background-color: var(--color-background-accent);
-    padding: 0;
-    background-color: var(--color-background);
-    color: var(--clr-gris-moyen);
-    border-radius: var(--border-radius);
-    max-width: var(--popup-width);
-    font-size: var(--sz-300);
-    box-shadow: 0px 4px 4px rgba(53, 53, 53, 0.25);
-}
-
 header {
     background-color: var(--header-background-color);
     border-radius: var(--border-radius) var(--border-radius) 0 0;
@@ -211,4 +199,20 @@ header .title {
 .v-step__button:not([data-disabled="true"]):hover {
     opacity: 0.8;
 }
+</style>
+<style>  /* global */
+/* Note: the following must be global with aggressive CSS selectors (e.g. IDs)
+   due to v-step sticky directly adding a <body> element, outside of the parent.
+ */
+#v-step {
+    --header-background-color: var(--color-background-accent);
+    padding: 0;
+    background-color: var(--color-background);
+    color: var(--clr-gris-moyen);
+    border-radius: var(--border-radius);
+    max-width: var(--popup-width);
+    font-size: var(--sz-300);
+    box-shadow: 0px 4px 4px rgba(53, 53, 53, 0.25);
+}
+
 </style>

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -193,7 +193,7 @@ export default {
     tutorial_prev: "Précédent",
     tutorial_stop: "Quitter le tour",
     tutorial_step_msg: "Étape {0} de {1}",
-    tutorial_welcome_html: "<p>Bienvenu sur la <b>Carte climat</b>!</p><p>Explorez les effets des changements climatiques sur le Québec.</p>",
+    tutorial_welcome_html: "<p>Bienvenue sur la <b>Carte climat</b>!</p><p>Explorez les effets des changements climatiques sur le Québec.</p>",
     tutorial_temperature_html: "<p>Voici la température pour l'<b>année</b> et la <b>région</b> sélectionnées.</p><p>Notez les changements par rapport à la température de 1990.</p>",
     tutorial_year_html: "<p>Vous pouvez changer l'<b>année en cours</b> pour explorer les données historiques et les projections futures.</p>",
     tutorial_catastrophes_html: "<p>Voici la quantité d'<b>événements extrêmes</b> pour l'année en cours.</p><p>Pour contrôler les filtres, appuyez à cet endroit.</p>",

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -177,7 +177,7 @@ export default {
 
     // About
     about: "À propos",
-    made_with_love: "La carte climat a été conçu avec amour grâce à une collaboration entre Équiterre, Bleuet Design ainsi que trois programmeurs bénévoles.",
+    made_with_love: "La Carte climat a été conçu avec amour grâce à une collaboration entre Équiterre, Bleuet Design ainsi que trois programmeurs bénévoles.",
     data_source: "Les données utilisées dans ce logiciel proviennent du {0}, du {1} ainsi que du {2}.",
     ouranos: "consortium Ouranos",
     url_ouranos: "https://www.ouranos.ca/",
@@ -193,7 +193,7 @@ export default {
     tutorial_prev: "Précédent",
     tutorial_stop: "Quitter le tour",
     tutorial_step_msg: "Étape {0} de {1}",
-    tutorial_welcome_html: "<p>Bienvenu sur la <b>carte climat</b>!</p><p>Explorez les effets des changements climatiques sur le Québec.</p>",
+    tutorial_welcome_html: "<p>Bienvenu sur la <b>Carte climat</b>!</p><p>Explorez les effets des changements climatiques sur le Québec.</p>",
     tutorial_temperature_html: "<p>Voici la température pour l'<b>année</b> et la <b>région</b> sélectionnées.</p><p>Notez les changements par rapport à la température de 1990.</p>",
     tutorial_year_html: "<p>Vous pouvez changer l'<b>année en cours</b> pour explorer les données historiques et les projections futures.</p>",
     tutorial_catastrophes_html: "<p>Voici la quantité d'<b>événements extrêmes</b> pour l'année en cours.</p><p>Pour contrôler les filtres, appuyez à cet endroit.</p>",

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -193,6 +193,7 @@ export default {
     tutorial_prev: "Précédent",
     tutorial_stop: "Quitter le tour",
     tutorial_step_msg: "Étape {0} de {1}",
+    tutorial_welcome_html: "<p>Bienvenu sur la <b>carte climat</b>!</p><p>Explorez les effets des changements climatiques sur le Québec.</p>",
     tutorial_temperature_html: "<p>Voici la température pour l'<b>année</b> et la <b>région</b> sélectionnées.</p><p>Notez les changements par rapport à la température de 1990.</p>",
     tutorial_year_html: "<p>Vous pouvez changer l'<b>année en cours</b> pour explorer les données historiques et les projections futures.</p>",
     tutorial_catastrophes_html: "<p>Voici la quantité d'<b>événements extrêmes</b> pour l'année en cours.</p><p>Pour contrôler les filtres, appuyez à cet endroit.</p>",


### PR DESCRIPTION
This is also a workaround for having to point at a tutorial target that depends on loading data + positioning (added documentation for that on the first step, so we remember).

Having a no-target tutorial step makes the step element "sticky", which adds it directly to the body: https://github.com/Sitronik/v3-tour/blob/master/src/components/VStep.vue#L115-L116. This makes our styling no longer work in that case, so we move the step styling to the global scope, with aggressive specificity to override the default v3-tour styling.