### PR TITLE
Un peu d'amour sur la timeline

### DIFF
--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -44,8 +44,8 @@ import { defineComponent, CSSProperties, PropType } from 'vue';
 import { REFERENCE_YEAR } from "@/models/constants";
 import { RegionStatistics } from '@/models/yearly_data';
 
-const START_NOTCH = -1;
-const END_NOTCH = 7;
+export const START_NOTCH = -1;
+export const END_NOTCH = 7;
 const NOTCH_STEPS = 1;  // Only display a notch every NOTCH_STEPS notches
 const NUM_NOTCHES = END_NOTCH - START_NOTCH + 1;
 

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,6 +1,16 @@
 <template>
     <div class="timeline">
-        <div id="slidertitle" v-t="`timeline_mode_${mode}`">
+        <div id="slider-header">
+            <div id="slider-title" v-t="`timeline_mode_${mode}`"></div>
+            <div id="mode-container">
+                <div class="item" v-for="value of Object.values(TimelineMode)" :title="$t(`timeline_mode_${value}`)">
+                    <input name="mode" type="radio" :id="`radio-${value}`" :value="value" :checked="mode === value"
+                        @change="mode = value" :class="value">
+                    <label :for="`radio-${value}`" :class="{active: value === mode, inactive: value !== mode}">
+                        <img :src="`/Button/${value}.svg`" :alt="value">
+                    </label>
+                </div>
+            </div>
         </div>
         <div class="timeline-container">
             <div class="timeline-graph">
@@ -35,15 +45,6 @@
                         <TimelineArrow class="slider-arrow"></TimelineArrow>
                     </template>
                 </vue-slider>
-            </div>
-        </div>
-        <div id="mode-container">
-            <div class="item" v-for="value of Object.values(TimelineMode)" :title="$t(`timeline_mode_${value}`)">
-                <input name="mode" type="radio" :id="`radio-${value}`" :value="value" :checked="mode === value"
-                    @change="mode = value" :class="value">
-                <label :for="`radio-${value}`" :class="{active: value === mode, inactive: value !== mode}">
-                    <img :src="`/Button/${value}.svg`" :alt="value">
-                </label>
             </div>
         </div>
     </div>
@@ -341,11 +342,16 @@ ChartJS.register(new VerticalLinePlugin());
 </script>
 
 <style scoped>
-#slidertitle {
-    font-size: var(--sz-400);
-    height: var(--sz-700);
+#slider-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    height: var(--sz-800);
+    padding-left: 4px;
+}
+
+#slider-title {
+    font-size: var(--sz-500);
 }
 
 .slider-container input {
@@ -422,13 +428,14 @@ ChartJS.register(new VerticalLinePlugin());
 }
 
 .timeline {
-    padding: 4px var(--timeline-horizontal-padding) var(--sz-50) var(--timeline-horizontal-padding);
+    padding-left: 4px;
+    padding-top: 4px;
 }
 
 .timeline-container {
     /* Undo the timeline component padding to push to the left side */
-    margin-left: calc(0px - var(--timeline-horizontal-padding));
-    padding-right: var(--sz-50);
+    margin-left: calc(0px - var(--timeline-horizontal-padding));    
+    padding: 0 var(--timeline-horizontal-padding) var(--sz-50) var(--timeline-horizontal-padding);
     cursor: pointer;
 }
 
@@ -439,20 +446,19 @@ ChartJS.register(new VerticalLinePlugin());
 
 
 #mode-container {
-    position: absolute;
-    right: 4px;
-    top: 4px;
     background-color: var(--clr-brun-terreux);
     border-radius: var(--border-radius);
+    margin: calc(var(--border-radius) / 4);
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 4px;
-    height: var(--sz-700);
+    height: 100%;
+    padding: 2px 4px;
 }
 
 #mode-container .item {
-    height: 100%;
+    width: calc(var(--sz-800) - 8px);
+    height: calc(var(--sz-800) - 8px);
 }
 
 #mode-container input {
@@ -463,12 +469,14 @@ ChartJS.register(new VerticalLinePlugin());
     display: block;
     cursor: pointer;
     border-radius: 50%;
+    width: 100%;
     height: 100%;
 }
 
 #mode-container label img {
     object-fit: contain;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
 }
 
 #mode-container label.active {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -116,6 +116,13 @@ export default defineComponent({
         const sliderContainer = ref<HTMLDivElement | null>(null);
         const onAfterFit = (axis: Scale<CoreScaleOptions>) => {
             if (sliderContainer.value) {
+                // Update slider margins to align them properly with the chart
+                // On the left, we minimally add the width of the Y axis so the slider
+                // begins with the chart itself.
+                // Additionnally, in catastrophe mode, we add half of bar's width on
+                // either side so that the edges of the timeline correspond to the centre
+                // of both the first and last bars. This is necessary to avoid a misalignment
+                // between the timeline and the chart in that mode
                 switch (mode.value) {
                     case TimelineMode.Temperature:
                         sliderContainer.value.style.marginLeft = `${axis.width}px`;

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -5,9 +5,9 @@
         <div class="timeline-container">
             <div class="timeline-graph">
                 <!-- set width to 0 to let it auto-size it with given height. -->
-                <Line v-if="mode === TimelineMode.Temperature" :chart-data="temperatureData" :height="90" :width="0"
+                <Line v-if="mode === TimelineMode.Temperature" :chart-data="temperatureData" :height="100" :width="0"
                     :chart-options="temperatureOptions" />
-                <Bar v-if="mode === TimelineMode.CatastropheCount" :chart-data="catastropheData" :height="90" :width="0"
+                <Bar v-if="mode === TimelineMode.CatastropheCount" :chart-data="catastropheData" :height="100" :width="0"
                     :chart-options="catastropheOptions" />
             </div>
             <div class="slider-container" ref="sliderContainer">
@@ -65,6 +65,7 @@ import { getRelativePosition } from 'chart.js/helpers';
 import TimelineArrow from './TimelineArrow.vue';
 import { Chart as ChartJS, ChartEvent, ActiveElement, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PointElement, LineElement, ScriptableContext, Filler, ChartData, Color, ChartOptions, CoreScaleOptions, Scale } from 'chart.js'
 import { numberFormats } from '@/locales/formats';
+import { END_NOTCH, START_NOTCH } from './Thermometer.vue';
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PointElement, LineElement, Filler)
 ChartJS.defaults.font.family = "Matter";
@@ -163,7 +164,9 @@ export default defineComponent({
                     ticks: {
                         stepSize: 2,
                         format: numberFormats.temperature_delta_int,
-                    }
+                    },
+                    max: END_NOTCH,
+                    min: START_NOTCH
                 },
             },
         }))).toJS() as ChartOptions<'line'>;
@@ -219,7 +222,7 @@ export default defineComponent({
                         data: pastData,
                         backgroundColor: this.makeGradientGenerator(
                             'rgb(255, 59, 59)', 'rgb(240, 173, 0)',
-                            'rgb(244, 243, 231)', 'rgb(0, 90, 173)'),
+                            'rgb(244, 243, 231)', 'rgb(0, 90, 173)')
                     },
                     {
                         ...datasetBase,
@@ -291,7 +294,6 @@ export default defineComponent({
 <style scoped>
 #slidertitle {
     font-size: var(--sz-400);
-    margin-bottom: var(--sz-50);
 }
 
 .slider-container input {
@@ -448,7 +450,7 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     gap: 2px;
-    height: 80px;
+    height: 76px;
     top: unset !important;
 }
 

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -194,8 +194,6 @@ export default defineComponent({
                     ticks: {
                         stepSize: 100,
                     },
-                    max: 600,
-                    min: 0
                 },
             },
         }))).toJS() as ChartOptions<'bar'>;

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -432,8 +432,8 @@ ChartJS.register(new VerticalLinePlugin());
 
 .timeline-container {
     /* Undo the timeline component padding to push to the left side */
-    margin-left: calc(0px - var(--timeline-horizontal-padding));    
-    padding: 0 var(--timeline-horizontal-padding) var(--sz-50) var(--timeline-horizontal-padding);
+    margin-left: calc(0px - var(--timeline-horizontal-padding));
+    padding: 0 calc(var(--timeline-horizontal-padding) + var(--sz-50)) var(--sz-50) var(--timeline-horizontal-padding);
     cursor: pointer;
 }
 


### PR DESCRIPTION
Notamment:
- On limite le graphe de température de -1 à 7, pour matcher le thermomètre. Ça donne une température qui sort du graphe en 2100, mais je trouve l'effet intéressant, comme si ça explosait les limites.
- On "squeeze" encore plus le slider en mode catastrophe. L'inconvénient c'est que le slider "bouge" donc au changement de mode, mais l'avantage c'est qu'avec ça on a des barres de graphe parfaitement alignées peu importe la résolution, donc je pense que ça vaut le coût.
- Ajustements de margins et paddings divers pour minimiser le dead space
- Les boutons de mode scalent maintenant avec la résolution au lieu de déborder sur des plus petits écrans.
- On affiche maintenant une ligne pointillée en 2022
- Correction d'un bogue d'affichage ou la ligne pointillée de la poignée du slider avait une largeur double