### PR TITLE
Fix marks to be objects with properly set value

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts">
-import VueSlider, { Marks, MarkOption } from 'vue-slider-component'
+import VueSlider, { Mark, Marks } from 'vue-slider-component'
 import { Map, Repeat, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
@@ -258,7 +258,7 @@ export default defineComponent({
                 marks[index] = {
                     value: index,
                     label: year.toString(),
-                };
+                } as Mark;
                 return marks;
             }, {} as Marks);
         },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -13,7 +13,7 @@
             <div class="slider-container" ref="sliderContainer">
                 <vue-slider v-model="selectedValue" :tooltip="'always'"
                     :marks="marks" :included="true" :min="0" :max="VISUAL_YEARS.totalYearsPadded - 1"
-                    :adsorb="true" :drag-on-click="true">
+                    :adsorb="true" :drag-on-click="true" :use-keyboard="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']"
@@ -52,7 +52,7 @@
 
 <script lang="ts">
 import VueSlider, { Marks, MarkOption } from 'vue-slider-component'
-import { Map, Repeat, fromJS } from 'immutable';
+import { Map, Range, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
 import { CONTINUOUS_YEARS, MAX_CONTINUOUS_YEAR, MIN_CONTINUOUS_YEAR, MODELED_YEARS, TIMELINE_YEARS } from '@/models/constants';
@@ -254,7 +254,11 @@ export default defineComponent({
     methods: { 
         generateMarks(): Marks {
             return TIMELINE_YEARS.reduce((marks, year) => {
-                marks[VISUAL_YEARS.yearToIndex(year)] = year.toString();
+                const index = VISUAL_YEARS.yearToIndex(year);
+                marks[index] = {
+                    value: index,
+                    label: year.toString(),
+                };
                 return marks;
             }, {} as Marks);
         },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -13,7 +13,7 @@
             <div class="slider-container" ref="sliderContainer">
                 <vue-slider v-model="selectedValue" :tooltip="'always'"
                     :marks="marks" :included="true" :min="0" :max="VISUAL_YEARS.totalYearsPadded - 1"
-                    :adsorb="true" :drag-on-click="true" :use-keyboard="true">
+                    :adsorb="true" :drag-on-click="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']"
@@ -52,7 +52,7 @@
 
 <script lang="ts">
 import VueSlider, { Marks, MarkOption } from 'vue-slider-component'
-import { Map, Range, fromJS } from 'immutable';
+import { Map, Repeat, fromJS } from 'immutable';
 import { computed, PropType, defineComponent, ref } from 'vue';
 import 'vue-slider-component/theme/default.css'
 import { CONTINUOUS_YEARS, MAX_CONTINUOUS_YEAR, MIN_CONTINUOUS_YEAR, MODELED_YEARS, TIMELINE_YEARS } from '@/models/constants';


### PR DESCRIPTION
Otherwise, the value was inferred to be the object key, which makes it a string, while the value compared e.g. when doing keyboard handling is an integer:
https://github.com/NightCatSama/vue-slider-component/blob/a1b8b2d776ff9553e10c23894e7040a14aeaa002/lib/vue-slider.tsx#L743 which would make it fail to match and cause problems.

This should resolve issues like in https://github.com/Drahakar/vireauvert/pull/224 based on my testing