### PR TITLE
Move breakpoint to 2013, >=2014 is predicted

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -22,7 +22,7 @@
             </div>
             <div class="slider-container" ref="sliderContainer">
                 <vue-slider v-model="selectedValue" :tooltip="'always'" :marks="marks" :included="true" :min="0"
-                    :max="VISUAL_YEARS.totalYearsPadded - 1" :adsorb="true" :drag-on-click="true">
+                    :max="VISUAL_YEARS.totalYearsPadded - 1" :drag-on-click="true">
                     <template v-slot:label="{value}">
                         <div class="markline"></div>
                         <div :class="['vue-slider-mark-label', 'custom-label']"

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,13 +1,21 @@
 import { Range } from 'immutable';
 
 export const REFERENCE_YEAR = 1990;  // For delta temperatures
-export const MIN_CONTINUOUS_YEAR = REFERENCE_YEAR;
-export const MAX_CONTINUOUS_YEAR = 2022;
-export const CONTINUOUS_YEARS = Range(MIN_CONTINUOUS_YEAR, MAX_CONTINUOUS_YEAR + 1).toArray();
+export const CURRENT_YEAR = new Date().getFullYear();
 
-// NOTE: Past 2035, we only have data for 2050 and 2100.
+// For these years, we have historical data.
+export const MIN_HISTORICAL_YEAR = REFERENCE_YEAR;
+export const MAX_HISTORICAL_YEAR = 2013;
+export const HISTORICAL_YEARS = Range(MIN_HISTORICAL_YEAR, MAX_HISTORICAL_YEAR + 1).toArray();
+
+// For the next years, we have continuous prediction data.
+export const MIN_PREDICTION_YEARS = MAX_HISTORICAL_YEAR + 1;
+export const MAX_PREDICTION_YEARS = CURRENT_YEAR;  // only show up to today
+export const PREDICTION_YEARS = Range(MIN_PREDICTION_YEARS, MAX_PREDICTION_YEARS + 1).toArray();
+
+// NOTE: After 2035, we only have data for 2050 and 2100.
 // NOTE: timeline CSS has assumptions that all modeled years end in 0.
 export const MODELED_YEARS = [2030, 2050, 2100];
 
+export const CONTINUOUS_YEARS = HISTORICAL_YEARS.concat(PREDICTION_YEARS).sort();
 export const TIMELINE_YEARS = CONTINUOUS_YEARS.concat(MODELED_YEARS).sort();
-export const CURRENT_YEAR = new Date().getFullYear();


### PR DESCRIPTION
- Rename constants to differentiate between historical, predicted, and modeled years;
- Put vertical line on last historical year for temperatures, current year for catastrophes;
- Drive-by reduce number of padding years to give more real-estate to other years to make it easier to switch between years;
- Disable `adsorb` on vue slider, hopefully makes it easier to switch years on mobile.

![image](https://user-images.githubusercontent.com/1843555/192163557-844e28bc-66e9-4719-8c8c-5c6cdc64baa9.png)

---

![image](https://user-images.githubusercontent.com/1843555/192163569-dedbafd0-a8ef-4139-8e3e-6990e754c47a.png)

---

![image](https://user-images.githubusercontent.com/1843555/192163595-6da96c0f-42d8-4fee-a163-82974d675563.png)
