### PR TITLE
Color unification

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -18,11 +18,11 @@
   --clr-jaune: #f0ad00;
   --clr-brun-terreux: #664500;
 
-  --clr-thermometer-mercury: #c9655e;
   --clr-thermometer-background: var(--color-background);
   --clr-thermometer-border: var(--clr-blanc);
   /* IFCHANGE: Change Thermometer.vue as well. */
   --clr-thermometer-low: #99C5DD;
+  --clr-thermometer-zero: #E5E3E2;
 
   --clr-flood: #00A6CA;
   --clr-forest-fire: #EC772E;

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -21,6 +21,8 @@
   --clr-thermometer-mercury: #c9655e;
   --clr-thermometer-background: var(--color-background);
   --clr-thermometer-border: var(--clr-blanc);
+  /* IFCHANGE: Change Thermometer.vue as well. */
+  --clr-thermometer-low: #99C5DD;
 
   --clr-flood: #00A6CA;
   --clr-forest-fire: #EC772E;

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -20,7 +20,7 @@
 
   --clr-thermometer-background: var(--color-background);
   --clr-thermometer-border: var(--clr-blanc);
-  /* IFCHANGE: Change Thermometer.vue as well. */
+  /* IFCHANGE: Change utils/colours.ts as well. */
   --clr-thermometer-low: #99C5DD;
   --clr-thermometer-zero: #E5E3E2;
 

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -47,6 +47,11 @@ export const END_NOTCH = 7;
 const NOTCH_STEPS = 1;  // Only display a notch every NOTCH_STEPS notches
 const NUM_NOTCHES = END_NOTCH - START_NOTCH + 1;
 
+/* Visually, the lowest notch is this much % into the stem height */
+const NOTCH_OFFSET = 0.1;
+/* Visually, the highest notch is this much % higher than NOTCH_OFFSET */
+const NOTCH_HEIGHT = 0.85;
+
 const RISKY_DELTA = 1.5;  // Show different visuals for ref temperature + this.
 
 
@@ -92,6 +97,8 @@ export default defineComponent({
                 '--current-value': this.valueToNotchIndex(this.currentValue),
                 '--reference-value': this.valueToNotchIndex(this.referenceValue),
                 '--risky-value': this.valueToNotchIndex(this.riskyValue),
+                '--notch-offset': `${NOTCH_OFFSET * 100}%`,
+                '--notch-height': `${NOTCH_HEIGHT * 100}%`,
             };
         },
         emojiPath(): string {
@@ -175,10 +182,6 @@ export default defineComponent({
 .wrapper {
     --sz-stem-width: var(--sz-300);
     --sz-stem-border: 2px;
-    /* the lowest notch is this much % into the stem height */
-    --notch-offset: 10%;
-    /* the highest notch is this much % higher than notch-offset */
-    --notch-height: 85%;
     --sz-bulb: var(--sz-900);
     /* limit values where we start clamping */
     --notch-min: var(--sz-bulb) / 2;

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -11,10 +11,8 @@
 
         <div class="thermometer">
             <div class="stem">
-                <!-- Note: last ones gets drawn on top of previous ones. -->
-                <div class="mercury mercury-danger tracked-current track-height"></div>
-                <div class="mercury mercury-risky tracked-max-risky track-height"></div>
-                <div class="mercury mercury-reference tracked-max-reference track-height"></div>
+                <div class="mercury tracked-current track-height"
+                     :style="mercuryStyle"></div>
             </div>
             <div class="bulb">
                 <p class="bulb-text">°C</p>
@@ -41,6 +39,7 @@
 <script lang="ts">
 
 import { defineComponent, CSSProperties, PropType } from 'vue';
+import { TEMPERATURE_THEME } from "@/utils/colours";
 import { REFERENCE_YEAR } from "@/models/constants";
 import { RegionStatistics } from '@/models/yearly_data';
 
@@ -104,7 +103,21 @@ export default defineComponent({
             } else {
                 return '/icons/Emoji3.png';
             }
-        }
+        },
+        mercuryStyle() {
+            // TODO: take into account 'notch padding' that we use.
+            // TODO: color bulb with minimum temperature
+            // TODO: stop gradient from flickering on changes
+            const max = Math.max(START_NOTCH, this.currentValue);
+            const gradient = TEMPERATURE_THEME.toGradientStops(START_NOTCH, max).map(stop => {
+                const colour = stop.colour.toHex();
+                const percent = stop.ratio * 100;
+                return `${colour} ${percent}%`;
+            }).join(', ');
+            return {
+                'background': `linear-gradient(0deg, ${gradient})`,
+            };
+        },
     },
     methods: {
         valueToNotchIndex(value: number): number {
@@ -130,16 +143,6 @@ export default defineComponent({
 .tracked-risky {
     /* Use this class to track the 'risky' value on the thermometer */
     --tracked-value: var(--risky-value);
-}
-
-.tracked-max-risky {
-    /* Will follow current up to 'risky', but not past that */
-    --tracked-value: min(var(--current-value), var(--risky-value));
-}
-
-.tracked-max-reference {
-    /* Will follow current up to 'reference', but not past that */
-    --tracked-value: min(var(--current-value), var(--reference-value));
 }
 
 .track-height, .track-bottom {
@@ -204,18 +207,6 @@ export default defineComponent({
     width: var(--sz-stem-width);
     position: absolute;
     bottom: 0;
-}
-
-.mercury-reference {
-    background-color: var(--clr-thermometer-mercury);
-}
-
-.mercury-risky {
-    background-color: var(--clr-jaune);
-}
-
-.mercury-danger {
-    background-color: var(--clr-alerte);
 }
 
 .notch {

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -11,8 +11,7 @@
 
         <div class="thermometer">
             <div class="stem">
-                <div class="mercury tracked-current track-height"
-                     :style="mercuryStyle"></div>
+                <div class="mercury tracked-current track-clip-top" :style="mercuryStyle"></div>
             </div>
             <div class="bulb">
                 <p class="bulb-text">°C</p>
@@ -107,8 +106,7 @@ export default defineComponent({
         mercuryStyle() {
             // TODO: take into account 'notch padding' that we use.
             // TODO: color bulb with minimum temperature
-            // TODO: stop gradient from flickering on changes
-            const max = Math.max(START_NOTCH, this.currentValue);
+            const max = Math.max(START_NOTCH, END_NOTCH);
             const gradient = TEMPERATURE_THEME.toGradientStops(START_NOTCH, max).map(stop => {
                 const colour = stop.colour.toHex();
                 const percent = stop.ratio * 100;
@@ -145,7 +143,7 @@ export default defineComponent({
     --tracked-value: var(--risky-value);
 }
 
-.track-height, .track-bottom {
+.track-height, .track-bottom, .track-clip-top {
     /* value to assign to e.g. height or bottom to match the --tracked-value */
     --tracked-point: clamp(
         var(--notch-min),
@@ -163,8 +161,13 @@ export default defineComponent({
     transition: bottom var(--mercury-transition);
 }
 
+.track-clip-top {
+    clip-path: inset(calc(100% - var(--tracked-point)) 0 0 0);
+    transition: clip-path var(--mercury-transition);
+}
+
 @media (prefers-reduced-motion: reduce) {
-    .track-height, .track-bottom {
+    .track-height, .track-bottom, .track-clip-top {
         transition: none;
     }
 }
@@ -204,6 +207,7 @@ export default defineComponent({
 }
 
 .mercury {
+    height: 100%;
     width: var(--sz-stem-width);
     position: absolute;
     bottom: 0;

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -52,6 +52,16 @@ const NOTCH_OFFSET = 0.1;
 /* Visually, the highest notch is this much % higher than NOTCH_OFFSET */
 const NOTCH_HEIGHT = 0.85;
 
+// Some helper values based on these:
+const BOTTOM_GAP = NOTCH_OFFSET;
+const TOP_GAP = 1 - (NOTCH_OFFSET + NOTCH_HEIGHT);
+const TEMP_RANGE = (END_NOTCH - START_NOTCH) / NOTCH_HEIGHT;
+
+// Taking into account the notch offset/height, these are the lowest/highest
+// temperatures that can be shown on the thermometer.
+const LOWEST_TEMP = START_NOTCH - BOTTOM_GAP * TEMP_RANGE;
+const HIGHEST_TEMP = END_NOTCH + TOP_GAP * TEMP_RANGE;
+
 const RISKY_DELTA = 1.5;  // Show different visuals for ref temperature + this.
 
 
@@ -111,12 +121,7 @@ export default defineComponent({
             }
         },
         mercuryStyle() {
-            const size = END_NOTCH - START_NOTCH;
-            const downGap = NOTCH_OFFSET * size;
-            const upGap = (1 - NOTCH_OFFSET - NOTCH_HEIGHT) * size;
-            const min = START_NOTCH - downGap;
-            const max = END_NOTCH + upGap;
-            const gradient = TEMPERATURE_THEME.toGradientStops(min, max).map(stop => {
+            const gradient = TEMPERATURE_THEME.toGradientStops(LOWEST_TEMP, HIGHEST_TEMP).map(stop => {
                 const colour = stop.colour.toHex();
                 const percent = stop.ratio * 100;
                 return `${colour} ${percent}%`;

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -105,7 +105,7 @@ export default defineComponent({
         },
         mercuryStyle() {
             // TODO: take into account 'notch padding' that we use.
-            // TODO: color bulb with minimum temperature
+            // TODO: color 1990 with matching neutral color?
             const max = Math.max(START_NOTCH, END_NOTCH);
             const gradient = TEMPERATURE_THEME.toGradientStops(START_NOTCH, max).map(stop => {
                 const colour = stop.colour.toHex();
@@ -235,7 +235,7 @@ export default defineComponent({
 
 .bulb {
     position: absolute;
-    background-color: var(--clr-thermometer-mercury);
+    background-color: var(--clr-thermometer-low);
     width: var(--sz-bulb);
     height: var(--sz-bulb);
     left: calc(50% - var(--sz-bulb) / 2);
@@ -249,7 +249,7 @@ export default defineComponent({
     display: block;
     width: var(--sz-stem-width);
     height: 6px;
-    background-color: var(--clr-thermometer-mercury);
+    background-color: var(--clr-thermometer-low);
     top: -3px;
     left: calc(50% - var(--sz-stem-width) / 2);
 }

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -111,7 +111,6 @@ export default defineComponent({
             }
         },
         mercuryStyle() {
-            // TODO: color 1990 with matching neutral color?
             const size = END_NOTCH - START_NOTCH;
             const downGap = NOTCH_OFFSET * size;
             const upGap = (1 - NOTCH_OFFSET - NOTCH_HEIGHT) * size;
@@ -302,7 +301,8 @@ export default defineComponent({
 
 .reference-value {
     width: 11ch;
-    background-color: var(--clr-thermometer-mercury);
+    color: var(--color-text);
+    background-color: var(--clr-thermometer-zero);
     font-size: var(--sz-200);
     padding: 2px 6px;
 }

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -111,10 +111,13 @@ export default defineComponent({
             }
         },
         mercuryStyle() {
-            // TODO: take into account 'notch padding' that we use.
             // TODO: color 1990 with matching neutral color?
-            const max = Math.max(START_NOTCH, END_NOTCH);
-            const gradient = TEMPERATURE_THEME.toGradientStops(START_NOTCH, max).map(stop => {
+            const size = END_NOTCH - START_NOTCH;
+            const downGap = NOTCH_OFFSET * size;
+            const upGap = (1 - NOTCH_OFFSET - NOTCH_HEIGHT) * size;
+            const min = START_NOTCH - downGap;
+            const max = END_NOTCH + upGap;
+            const gradient = TEMPERATURE_THEME.toGradientStops(min, max).map(stop => {
                 const colour = stop.colour.toHex();
                 const percent = stop.ratio * 100;
                 return `${colour} ${percent}%`;

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -59,6 +59,7 @@ import { CONTINUOUS_YEARS, MAX_CONTINUOUS_YEAR, MIN_CONTINUOUS_YEAR, MODELED_YEA
 import { useCatastropheStore } from '@/stores/catastrophes';
 import { useStatisticStore } from '@/stores/statistics';
 import { FILTER_ALL_CATASTROPHES, CatastropheFilter } from '@/models/catastrophes';
+import { TEMPERATURE_THEME } from '@/utils/colours';
 import { InterpolatedYears } from '@/utils/interpolated_years';
 import { Line, Bar } from 'vue-chartjs'
 import { getRelativePosition } from 'chart.js/helpers';
@@ -300,18 +301,8 @@ export default defineComponent({
                 const chartArea = ctx.chart.chartArea;
                 if (!chartArea) return;  // not set on init
                 const yAxis = ctx.chart.scales.y;
-                const zeroRatio = -yAxis.min / (yAxis.max - yAxis.min);
                 const gradient = canvas.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
-
-                gradient.addColorStop(0.7, hotColor);
-                // put warm color slightly above zero to get a fast transition
-                // to non-"invisible" colors, e.g. when neutral is the same as
-                // the background color.
-                gradient.addColorStop(zeroRatio + 0.03, warmColor);
-                gradient.addColorStop(zeroRatio, neutralColor);
-                gradient.addColorStop(0, coldColor);
-
-                return gradient;
+                return TEMPERATURE_THEME.toCanvasGradient(gradient, yAxis.min, yAxis.max);
             };
         },
     },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -296,7 +296,10 @@ export default defineComponent({
                 if (!chartArea) return;  // not set on init
                 const yAxis = ctx.chart.scales.y;
                 const gradient = canvas.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
-                return TEMPERATURE_THEME.toCanvasGradient(gradient, yAxis.min, yAxis.max, alpha);
+                for (const stop of TEMPERATURE_THEME.toGradientStops(yAxis.min, yAxis.max)) {
+                    gradient.addColorStop(stop.ratio, stop.colour.toHex(alpha));
+                }
+                return gradient;
             };
         },
     },

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -245,16 +245,12 @@ export default defineComponent({
                     {
                         ...datasetBase,
                         data: pastData,
-                        backgroundColor: this.makeGradientGenerator(
-                            'rgb(255, 59, 59)', 'rgb(240, 173, 0)',
-                            'rgb(244, 243, 231)', 'rgb(0, 90, 173)')
+                        backgroundColor: this.makeGradientGenerator(1.0),
                     },
                     {
                         ...datasetBase,
                         data: futureData,
-                        backgroundColor: this.makeGradientGenerator(
-                            'rgba(255, 59, 59, 0.3)', 'rgba(240, 173, 0, 0.3)',
-                            'rgba(244, 243, 231, 0.3)', 'rgba(0, 90, 173, 0.3)'),
+                        backgroundColor: this.makeGradientGenerator(0.3),
                     },
                 ],
             } as ChartData<'line'>;
@@ -293,16 +289,14 @@ export default defineComponent({
                 return marks;
             }, {} as Marks);
         },
-        makeGradientGenerator(hotColor: string, warmColor: string,
-            neutralColor: string, coldColor: string
-        ): GradientGenerator {
+        makeGradientGenerator(alpha: number): GradientGenerator {
             return (ctx: ScriptableContext<'line'>) => {
                 const canvas = ctx.chart.ctx;
                 const chartArea = ctx.chart.chartArea;
                 if (!chartArea) return;  // not set on init
                 const yAxis = ctx.chart.scales.y;
                 const gradient = canvas.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
-                return TEMPERATURE_THEME.toCanvasGradient(gradient, yAxis.min, yAxis.max);
+                return TEMPERATURE_THEME.toCanvasGradient(gradient, yAxis.min, yAxis.max, alpha);
             };
         },
     },

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -81,6 +81,7 @@ export class ColourTheme {
 }
 
 export const TEMPERATURE_THEME = new ColourTheme([
+    // IFCHANGE: Change base.css as well.
     { temp_delta: -1.0, colour: Colour.fromHex('#99C5DD') },
     { temp_delta: +0.0, colour: Colour.fromHex('#E5E3E2') },
     { temp_delta: +1.5, colour: Colour.fromHex('#F0AD00') },

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -41,11 +41,17 @@ interface Stop {
     colour: Colour;
 }
 
+interface GradientStop {
+    ratio; number;
+    colour: Colour;
+}
+
 export class ColourTheme {
     stops: Stop[];
 
     constructor(stops: Stop[]) {
         this.stops = stops;
+
     }
 
     getColour(temp_delta: number): Colour {
@@ -62,15 +68,15 @@ export class ColourTheme {
         return previousStop.colour;  // Return the last stop's colour.
     }
 
-    toCanvasGradient(gradient: CanvasGradient, min: number, max: number, alpha: number): CanvasGradient {
-        // min & max refer to min and max delta temps shown on the canvas, to
-        // find the right breakpoints for specific temp deltas.
+    toGradientStops(min: number, max: number): GradientStop[] {
+        // min & max refer to min and max delta temps where the gradient is
+        // shown, to find the right breakpoints for specific temp deltas.
         const gap = max - min;
-        for (const stop of this.stops) {
-            const ratio = clamp((stop.temp_delta - min) / gap, 0.0, 1.0);
-            gradient.addColorStop(ratio, stop.colour.toHex(alpha));
-        }
-        return gradient;
+        // TODO: don't include stops that are outside ranges
+        return this.stops.map(stop => ({
+            ratio: clamp((stop.temp_delta - min) / gap, 0.0, 1.0),
+            colour: stop.colour,
+        }));
     }
 }
 

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -72,7 +72,6 @@ export class ColourTheme {
         // min & max refer to min and max delta temps where the gradient is
         // shown, to find the right breakpoints for specific temp deltas.
         const gap = max - min;
-        // TODO: don't include stops that are outside ranges
         return this.stops.map(stop => ({
             ratio: clamp((stop.temp_delta - min) / gap, 0.0, 1.0),
             colour: stop.colour,

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -53,12 +53,14 @@ export class ColourTheme {
         let previousStop = this.stops[0];
         for (const stop of this.stops) {
             if (temp_delta < stop.temp_delta) {
-                // TODO: Implement as a gradient, lerping colors.
-                return previousStop.colour;
+                const gap = stop.temp_delta - previousStop.temp_delta;
+                const value = temp_delta - previousStop.temp_delta;
+                const alpha = gap > 0 ? value / gap : 0.0;
+                return previousStop.colour.lerp(stop.colour, alpha);
             }
             previousStop = stop;
         }
-        return previousStop.colour;  // Return the last stop.
+        return previousStop.colour;  // Return the last stop's colour.
     }
 }
 

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -42,7 +42,7 @@ interface Stop {
 }
 
 interface GradientStop {
-    ratio; number;
+    ratio: number;
     colour: Colour;
 }
 

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -18,7 +18,7 @@ export class Colour {
         return new Colour(r, g, b);
     }
 
-    toHex(alpha: number = 1.0): string {
+    toHex(alpha = 1.0): string {
         function hexify(x: number) {
             const val = Math.min(Math.floor(x * 255), 255);
             return val.toString(16).padStart(2, '0');

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -62,13 +62,13 @@ export class ColourTheme {
         return previousStop.colour;  // Return the last stop's colour.
     }
 
-    toCanvasGradient(gradient: CanvasGradient, min: number, max: number): CanvasGradient {
+    toCanvasGradient(gradient: CanvasGradient, min: number, max: number, alpha: number): CanvasGradient {
         // min & max refer to min and max delta temps shown on the canvas, to
         // find the right breakpoints for specific temp deltas.
         const gap = max - min;
         for (const stop of this.stops) {
             const ratio = clamp((stop.temp_delta - min) / gap, 0.0, 1.0);
-            gradient.addColorStop(ratio, stop.colour.toHex());
+            gradient.addColorStop(ratio, stop.colour.toHex(alpha));
         }
         return gradient;
     }

--- a/src/utils/interpolated_years.ts
+++ b/src/utils/interpolated_years.ts
@@ -1,4 +1,5 @@
 import { Range } from 'immutable';
+import { clamp, lerp } from './math_helpers';
 
 // Helper to manage interpolated 'padding years' around modeled years, to
 // produce some visual padding.
@@ -72,9 +73,8 @@ export class InterpolatedYears {
         for (const current of data.slice(index)) {
             Range(0, this.padding).forEach(i => {
                 const ratio = (i + 1) / (this.padding + 1);
-                const lerp = (1 - ratio) * previous + ratio * current;
+                interpolated.data.push(lerp(previous, current, ratio));
                 interpolated.indices.push(index);
-                interpolated.data.push(lerp);
                 ++index;
             });
             interpolated.indices.push(index);
@@ -84,7 +84,3 @@ export class InterpolatedYears {
         return interpolated;
     }
 };
-
-function clamp(value: number, min: number, max: number): number {
-    return Math.min(max, Math.max(min, value));
-}

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -1,7 +1,7 @@
 import L from "leaflet";
 
 import { CatastropheGroup, CatastropheType } from "@/models/catastrophes";
-import { temperatureGradient, getGradientColourIndex, colourToHex, multiplyColours } from "./colours";
+import { DEFAULT_THEME } from "./colours";
 import { Feature, Geometry } from "geojson";
 import { DistrictProperties } from "@/models/map";
 import CatastropheDetails from "@/components/CatastropheDetails.vue";
@@ -31,10 +31,8 @@ const selectedStyle: L.PathOptions = {
 
 export function setMapLayerColour(layer: L.GeoJSON, selected: boolean, tempDelta?: number) {
     let style = selected ? selectedStyle : unselectedStyle;
-    if (tempDelta) {
-        let colour = temperatureGradient[getGradientColourIndex(tempDelta)];
-        colour = multiplyColours(colour, [1, 0, 0], 0.9);
-        style.fillColor = colourToHex(colour);
+    if (tempDelta !== undefined) {
+        style.fillColor = DEFAULT_THEME.getColour(tempDelta).toHex();
     }
     layer.setStyle(style);
 

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -1,7 +1,7 @@
 import L from "leaflet";
 
 import { CatastropheGroup, CatastropheType } from "@/models/catastrophes";
-import { DEFAULT_THEME } from "./colours";
+import { TEMPERATURE_THEME } from "./colours";
 import { Feature, Geometry } from "geojson";
 import { DistrictProperties } from "@/models/map";
 import CatastropheDetails from "@/components/CatastropheDetails.vue";
@@ -32,7 +32,7 @@ const selectedStyle: L.PathOptions = {
 export function setMapLayerColour(layer: L.GeoJSON, selected: boolean, tempDelta?: number) {
     let style = selected ? selectedStyle : unselectedStyle;
     if (tempDelta !== undefined) {
-        style.fillColor = DEFAULT_THEME.getColour(tempDelta).toHex();
+        style.fillColor = TEMPERATURE_THEME.getColour(tempDelta).toHex();
     }
     layer.setStyle(style);
 

--- a/src/utils/math_helpers.ts
+++ b/src/utils/math_helpers.ts
@@ -1,0 +1,7 @@
+export function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+export function lerp(a: number, b: number, ratio: number) {
+    return (1 - ratio) * a + ratio * b;
+}


### PR DESCRIPTION
Change timeline, thermometer, and map to all be colored based on the same gradient.

- Refactor color helper for convenience, create a new `ColourTheme` class to implement the gradient logic. We use this to get a color for a given temperature, and to generate unified gradients for the thermometer/timeline;
- Bug fix in `map_helpers`, where when tempDelta was 0 (e.g. in 1990), it wouldn't go in the branch because it's a falsy value (would do the same logic as when we don't pass a param);
- Change thermometer stem dynamic height handling to instead do `clip-path` with a fixed 100% height gradient, otherwise the gradient flickers when we constantly change the height/gradient dynamically;
- Change the thermometer bulb color to be the same min temperature "blue" color to fit visually with the gradient;
- Change the 1990 color to be the same as the color we use for 0 in the theme.

Minor changes:
- Create `math_helpers` to re-use `clamp`/`lerp`;
- Set JS constants for the thermometer start/end of the notches, because we need to know this to infer the minimum and maximum temperature that is shown in the gradient.

Visually:

1990

![image](https://user-images.githubusercontent.com/1843555/192178263-ba3899ba-6d11-4bc6-a600-824cf71ffac7.png)


---

1992

![image](https://user-images.githubusercontent.com/1843555/192178291-34efc5a3-4179-48cd-b5e1-2749088caeec.png)

---

2022

![image](https://user-images.githubusercontent.com/1843555/192178160-8fe47d06-2785-4e3b-98d5-aa5cca793f7e.png)

---

2050

![image](https://user-images.githubusercontent.com/1843555/192178199-7c278f3c-dbec-45ad-a4a5-a67791adc4d0.png)

---

2100

![image](https://user-images.githubusercontent.com/1843555/192178237-35c3b290-2c8a-4e06-b411-1bd7efa6288b.png)

