### PR TITLE
Fix tutorial width too large on mobile

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -67,7 +67,6 @@
   :root {
     --app-column-gap: var(--sz-100);
     --timeline-horizontal-padding: var(--sz-600);
-    --popup-width: 256px;
     --border-radius: 16px;
   }
 }


### PR DESCRIPTION
Keep the default value from above (216px), otherwise it overflows on some of our steps.