### PR TITLE
Réduction de la largeur des filtres.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -242,12 +242,11 @@ Sentry.init({
 
 .filter-inputs {
     flex: 1;
-    width: 100%;
     min-height: 0;
     /* don't expand to children content -- undo auto min-height */
     max-height: 100%;
-    max-width: 600px;
     padding-right: var(--sz-50);
+    align-self: flex-start;
 }
 
 .call-to-action {

--- a/src/components/CatastropheToggle.vue
+++ b/src/components/CatastropheToggle.vue
@@ -209,6 +209,7 @@ header:hover {
     flex: 1;
     white-space: nowrap;
     color: var(--clr-gris-mi-fonce);
+    padding-right: var(--sz-50);
 }
 
 .separator {


### PR DESCRIPTION
Les filtres (région, type de catastrophes) sont maintenant plus étroit et prennent maintenant un espace minimal sur l'écran plutôt que le 600px qu'ils consommaient avant.

![image](https://user-images.githubusercontent.com/4632802/192392942-c5c5fe3e-9646-4237-ba69-bdf52f4a8186.png)
