### PR TITLE
Positionnement du label futur

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -311,9 +311,6 @@ export default defineComponent({
                     },
                 ]
             } as ChartData<'bar'>;
-        },
-        futureWidth() {
-            return `${(1 - (VISUAL_YEARS.continuous.length / VISUAL_YEARS.totalYearsPadded)) * 100}%`;
         }
     },
     methods: {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -410,7 +410,7 @@ ChartJS.register(new LabelPositioningPlugin());
     width: calc(var(--sz-800) - 4px);
     height: calc(var(--sz-800) - 4px);
     pointer-events: auto;
-    margin-left: var(--sz-200);
+    margin-left: calc(var(--border-radius) / 4);
 }
 
 .timeline-toggle .toggle:hover {


### PR DESCRIPTION
Au lieu de hardcoder à 2022 avec une formule compliquée, on utilise un plugin ChartJS pour positionner adéquatement en fonction du mode sélectionné. Cela permet de centrer le label en toute situation.

Également, ajustement de la position du bouton de collapse pour qu'il suive le galbe de la bordure.

![image](https://user-images.githubusercontent.com/4632802/192395803-e2d2da15-ec1c-40e4-ac69-53aea6b7fc49.png)
