### PR TITLE
Remove highlight tutorial step

### DIFF
--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -118,7 +118,9 @@ export default defineComponent({
                     },
                 },
                 {
-                    target: '[data-tutorial-step="highlight"]',
+                    // Note: no target, otherwise causes corner cases when the
+                    // highlight is out-of-view or there's none for the current
+                    // year.
                     content: this.$t('tutorial_step_highlight'),
                     params: {
                         placement: "top",

--- a/src/locales/fr-CA.ts
+++ b/src/locales/fr-CA.ts
@@ -214,7 +214,7 @@ export default {
     tutorial_step_timeline: "<p>Vous pouvez changer l'<b>année</b> pour explorer les données de températures moyennes observées par le passé et les projections futures ainsi que les événements climatiques extrêmes survenus.</p>",
     tutorial_step_region_search: "<p>Sélectionnez la circonscription à afficher ou l'ensemble du Québec</p>",
     tutorial_step_catastrophes: "<p>Nombre d'événements extrêmes survenus dans la circonscription et l'année sélectionnées.</p><p>Vous pouvez sélectionner quels types d'événements extrêmes à afficher (ici un total de <b>3 événements extrêmes</b>, dont 2 tornades et 1 vague de chaleur en 2022)</p>",
-    tutorial_step_highlight: "<p>Certaines années contiennent des <b>faits saillants</b>. Cliquez sur l'icône brillante pour en savoir plus.</p>",
+    tutorial_step_highlight: "<p>Certaines années contiennent des <b>faits saillants</b>. Cliquez sur les icônes brillantes pour en savoir plus.</p>",
     tutorial_step_timeline_catastrophes_count: "<p>Visualisez le nombre d'<b>événements climatiques extrêmes</b> survenus depuis 1990 pour la province ou la circonscription sélectionnée.</p>",
     tutorial_step_call_to_action: "<p>Vous êtes préoccupé(e)s? <b>Contactez vos candidat(e)s</b> aux prochaines élections.</p>",    
     tutorial_step_end: "<p>Pour revoir ce tour guidé, ou pour de plus amples informations, consultez l'<b>aide</b>!</p>"

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -51,7 +51,7 @@ function generateIcons(baseClassName: string, generateAsInnerDiv: boolean): Map<
         };
         if (generateAsInnerDiv) {
             options.className = '';
-            options.html = `<div class="${baseClassName} catastrophe-icon-${value.toLowerCase()}" data-tutorial-step="highlight"></div>`;
+            options.html = `<div class="${baseClassName} catastrophe-icon-${value.toLowerCase()}"></div>`;
         } else {
             options.className = `${baseClassName} catastrophe-icon-${value.toLowerCase()}`;
         }


### PR DESCRIPTION
Otherwise we need to deal with the case where the highlight is off-screen (e.g. the person panned the map, then the tutorial step is shown off-screen) and when there is none (e.g. person switched to a future year).