### PR TITLE
Nettoyage des popups leaflet (catastrophes et highlights)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -107,6 +107,7 @@
 
 .popup-content-container {
   border-radius: var(--border-radius);
+  height: 100%;
 }
 
 .catastrophe-popup .leaflet-popup-content {
@@ -116,23 +117,28 @@
 }
 
 .leaflet-container a.leaflet-popup-close-button {
-  width: var(--sz-700);
-  height: var(--sz-700);
+  width: calc(var(--sz-900) - (var(--border-radius) / 2));
+  height:  calc(var(--sz-900) - (var(--border-radius) / 2));
   border-radius: 50%;
   background-color: var(--clr-gris-tres-pale);
-  background-image: url('/Button/Close.svg');
-  background-size: cover;
-  background-position: center;
-  margin-right: calc((var(--sz-900) - var(--sz-700)) / 2);
-  margin-top: calc((var(--sz-900) - var(--sz-700)) / 2);
+  position: absolute;
+  right: calc(var(--border-radius) / 4);
+  top: calc(var(--border-radius) / 4);
   z-index: 1000;
   cursor: pointer;
 }
 
-.leaflet-container a.leaflet-popup-close-button span {
-  display: none;
+.leaflet-container a.leaflet-popup-close-button img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
 }
 
 .catastrophe-popup .leaflet-popup-tip {
   background-color: var(--color-background);
+}
+
+.leaflet-popup-scrolled {
+  overflow: inherit;
+  border: 0;
 }

--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -1,12 +1,15 @@
 <template>
-    <div class="header">{{ group.city ? group.city : `${group.location.lat.toFixed(2)}, ${group.location.lng.toFixed(2)}` }}</div>
-    <ul id="catastrophe-list">
-        <li v-for="instance of group.instances">
-            <div class="icon" :class="[`catastrophe-icon-${instance.type.toLowerCase()}`]"></div>
-            <i18n-d tag="time" :value="instance.date" format="event_date_short"></i18n-d>
-            <div class="details" v-t="{path: 'catastrophe_with_severity', args: { catastrophe: instance }}"></div>
-        </li>
-    </ul>
+    <div class="modal">
+        <div class="header">{{ group.city ? group.city : `${group.location.lat.toFixed(2)},
+        ${group.location.lng.toFixed(2)}` }}</div>
+        <div id="catastrophe-list">
+            <template v-for="instance of group.instances">
+                <div class="icon" :class="[`catastrophe-icon-${instance.type.toLowerCase()}`]"></div>
+                <i18n-d tag="time" :value="instance.date" format="event_date_short"></i18n-d>
+                <div class="details" v-t="{path: 'catastrophe_with_severity', args: { catastrophe: instance }}"></div>
+            </template>
+        </div>
+    </div>
 </template>
 
 <script lang="ts">
@@ -34,13 +37,18 @@ export default defineComponent({
 });
 </script>
 <style scoped>
+.modal {
+  height: 100%;
+  overflow: hidden;
+  border-radius: var(--border-radius);
+}
+
 .header {
     font-size: var(--sz-400);
     background-color: var(--color-background-accent);
     height: var(--sz-900);
     padding-left: var(--sz-50);
     padding-right: var(--sz-50);
-    border-radius: var(--border-radius) var(--border-radius) 0 0;
     display: flex;
     align-items: center;
 }
@@ -53,23 +61,20 @@ time {
 }
 
 #catastrophe-list {
-    padding-left: var(--sz-200);
-    padding-right: var(--sz-10);
-    padding-bottom: var(--sz-30);
-}
-
-#catastrophe-list li {
-    list-style: none;
-    color: var(--clr-gris-moyen);
-    display: flex;
-    align-items: center;
-    gap: var(--sz-30);
-    margin-top: var(--sz-30);
+    padding: var(--sz-50) var(--sz-10) var(--sz-50) var(--sz-200);
+    height: calc(100% - var(--sz-900));
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: grid;
+    column-gap: var(--sz-30);
+    row-gap: var(--sz-50);
+    grid-template-columns: var(--sz-700) min-content auto;
     font-size: var(--sz-200);
+    color: var(--clr-gris-moyen);
+    align-items: center;
 }
 
 .icon {
-    width: var(--sz-700);
     height: var(--sz-700);
     background-size: cover;
     background-repeat: no-repeat;
@@ -84,6 +89,5 @@ time {
     padding-right: var(--sz-50);
     background-color: var(--color-background-accent);
     border-radius: var(--border-radius);
-    flex-grow: 1;
 }
 </style>

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -3,7 +3,9 @@
         <div class="icon" :class="[`catastrophe-icon-${highlight.type.toLowerCase()}`]"></div>
         <div class="title">{{ highlight.title ? highlight.title : $t(`catastrophe_${highlight.type}`, 2) }}</div>
     </div>
-    <div id="body-content" v-html="body"></div>
+    <div id="body-container">
+        <div id="body-content" v-html="body"></div>
+    </div>
 </template>
 
 <script lang="ts">
@@ -71,6 +73,14 @@ export default defineComponent({
     background-repeat: no-repeat;
     background-position: center;
     left: calc(var(--sz-30) * -1);
+    z-index: 1;
+}
+
+#body-container {
+    padding-top: var(--sz-30);
+    height: calc(100% - var(--sz-900));
+    overflow: hidden;
+    border-radius: var(--border-radius);
 }
 
 #body-content {
@@ -82,11 +92,15 @@ export default defineComponent({
     line-height: 1.5em;
 
     color: var(--clr-gris-moyen);
+
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
 }
 
 #body-content :deep(p) {
     margin: 0;
-    margin-top: var(--sz-30);
+    margin-bottom: var(--sz-30);
 }
 
 #body-content :deep(a) {

--- a/src/utils/map_helpers.ts
+++ b/src/utils/map_helpers.ts
@@ -86,7 +86,7 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
         closeButton.href = '#';
         closeButton.setAttribute('role', 'button');
         closeButton.ariaLabel = 'Close button';
-        closeButton.innerHTML = '<span aria-hidden="true">&#x00d7;</span>';
+        closeButton.innerHTML = '<img src="/Button/Close.svg">';
         closeButton.addEventListener('click', ev => {
             marker.closePopup();
             ev.preventDefault();
@@ -101,6 +101,9 @@ function createMarkerInternal(location: L.LatLngExpression, type: CatastropheTyp
     });
     marker.bindPopup(popup);
     marker.addEventListener('popupopen', ev => {
+        ev.popup.options.maxHeight = window.innerHeight / 3;
+        ev.popup.update();
+
         const elem = ev.popup.getElement();
         if(elem) {
             const popupContent = elem.querySelector('.leaflet-popup-content') as HTMLElement | null;


### PR DESCRIPTION
Ils ont maintenant une taille maximale en fonction de la taille verticale de l'écran, et affichent une scrollbar si le contenu ne rentre plus dans la fenêtre.

Également, j'ai réalisé que les lignes des catastrophes multiples étaient mal alignées horizontalement, et que les boutons de fermeture ne scalent pas sur la résolution comme ceux des modals.

![image](https://user-images.githubusercontent.com/4632802/192419540-6906e975-4c22-4ed8-b643-3ddd2fc51b1b.png)
![image](https://user-images.githubusercontent.com/4632802/192419599-afadc203-442b-47dd-94c6-93e8739622b7.png)
