### PR TITLE
Ajustement du look d'un fait saillant si son titre est long.

### DIFF
--- a/src/components/CatastropheDetails.vue
+++ b/src/components/CatastropheDetails.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     background-color: var(--color-background-accent);
     height: var(--sz-900);
     padding-left: var(--sz-200);
-    padding-right: var(--sz-50);
+    padding-right: var(--sz-900);
     display: flex;
     align-items: center;
 }

--- a/src/components/HighlightView.vue
+++ b/src/components/HighlightView.vue
@@ -53,13 +53,15 @@ export default defineComponent({
     background-color: var(--color-background-accent);
     border-radius: var(--border-radius) var(--border-radius) 0 var(--border-radius);
     height: var(--sz-900);
-    padding-right: var(--sz-50);
+    padding-right: var(--sz-900);
     display: flex;
     align-items: center;
 }
 
 .title {
     margin-left: calc(var(--sz-30) / -5);
+    line-height: 1em;
+    padding-right: var(--sz-10);
 }
 
 .icon {
@@ -68,6 +70,7 @@ export default defineComponent({
     object-fit: contain;
     width: calc(var(--sz-900) + var(--sz-50));
     height: calc(var(--sz-900) + var(--sz-50));
+    flex-shrink: 0;
     background-size: cover;
     border-radius: 50%;
     background-repeat: no-repeat;


### PR DESCRIPTION
Sinon ça pourrait déborder par dessus le bouton de fermeture.

Avant: 
![image](https://user-images.githubusercontent.com/4632802/192932005-129a970f-d4fb-4c21-adfe-5be3c3d53d3d.png)

Après:
![image](https://user-images.githubusercontent.com/4632802/192932013-4740c90b-a13b-43e8-9004-a2e499fb1270.png)
